### PR TITLE
Do not cache new k8s clients when using Dial

### DIFF
--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -5,12 +5,14 @@ package installer
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/kubeconfig"
 	"github.com/openshift/installer/pkg/asset/releaseimage"
 	"github.com/pkg/errors"
+	machnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -96,6 +98,10 @@ func (m *manager) initializeKubernetesClients(ctx context.Context) error {
 		return err
 	}
 	r.Dial = restconfig.DialContext(m.env, m.oc)
+
+	// https://github.com/kubernetes/kubernetes/issues/118703#issuecomment-1595072383
+	// TODO: Revert or adapt when upstream fix is available
+	r.Proxy = machnet.NewProxierWithNoProxyCIDR(http.ProxyFromEnvironment)
 
 	m.kubernetescli, err = kubernetes.NewForConfig(r)
 	return err

--- a/pkg/util/restconfig/restconfig.go
+++ b/pkg/util/restconfig/restconfig.go
@@ -8,7 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 
+	machnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -41,6 +43,10 @@ func RestConfig(dialer proxy.Dialer, oc *api.OpenShiftCluster) (*rest.Config, er
 	}
 
 	restconfig.Dial = DialContext(dialer, oc)
+
+	// https://github.com/kubernetes/kubernetes/issues/118703#issuecomment-1595072383
+	// TODO: Revert or adapt when upstream fix is available
+	restconfig.Proxy = machnet.NewProxierWithNoProxyCIDR(http.ProxyFromEnvironment)
 
 	return restconfig, nil
 }


### PR DESCRIPTION
In client-go 0.26.0+, every time you create a new client, there is a new entry created in TLS cache. The memory leak is described by https://github.com/kubernetes/kubernetes/issues/118703. That issue has not been resolved at the time of this writing, but describes a couple of workarounds. Try the one described in https://github.com/kubernetes/kubernetes/issues/118703#issuecomment-1595072383:

For now, I would probably just set the Proxy func to
utilnet.NewProxierWithNoProxyCIDR(http.ProxyFromEnvironment) so that
the TLS cache is skipped for your code. This isn't guaranteed behavior
and may stop working at any time, but it will at least solve the issue
for you for now (by restoring the old behavior).

We don't use client-go v0.26.0, but while this issue is fresh in our minds we will set ourselves up for success and future proof ourselves until a better solution exists.