### PR TITLE
ARO-6408 populate credentials mode

### DIFF
--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -20,6 +20,7 @@ type OpenShiftCluster struct {
 	SystemData SystemData                 `json:"systemData,omitempty"`
 	Tags       map[string]string          `json:"tags,omitempty"`
 	Properties OpenShiftClusterProperties `json:"properties,omitempty"`
+	Identity   *Identity                  `json:"identity,omitempty"`
 }
 
 // CreatedByType by defines user type, which executed the request
@@ -249,6 +250,26 @@ type PlatformWorkloadIdentity struct {
 	ResourceID   string `json:"resourceId,omitempty" mutable:"true"`
 	ClientID     string `json:"clientId,omitempty" swagger:"readOnly" mutable:"true"`
 	ObjectID     string `json:"objectId,omitempty" swagger:"readOnly" mutable:"true"`
+}
+
+// ClusterUserAssignedIdentity stores information about a user-assigned managed identity in a predefined format required by Microsoft's Managed Identity team.
+type ClusterUserAssignedIdentity struct {
+	MissingFields
+
+	ClientID    string `json:"clientId,omitempty"`
+	PrincipalID string `json:"principalId,omitempty"`
+}
+
+// UserAssignedIdentities stores a mapping from resource IDs of managed identities to their client/principal IDs.
+type UserAssignedIdentities map[string]ClusterUserAssignedIdentity
+
+// Identity stores information about the cluster MSI(s) in a workload identity cluster.
+type Identity struct {
+	MissingFields
+
+	Type                   string                 `json:"type,omitempty"`
+	UserAssignedIdentities UserAssignedIdentities `json:"userAssignedIdentities,omitempty"`
+	IdentityURL            string                 `json:"identityURL,omitempty" mutable:"true"`
 }
 
 // SoftwareDefinedNetwork

--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -116,7 +116,9 @@ type OpenShiftClusterProperties struct {
 
 	ConsoleProfile ConsoleProfile `json:"consoleProfile,omitempty"`
 
-	ServicePrincipalProfile ServicePrincipalProfile `json:"servicePrincipalProfile,omitempty"`
+	ServicePrincipalProfile *ServicePrincipalProfile `json:"servicePrincipalProfile,omitempty"`
+
+	PlatformWorkloadIdentityProfile *PlatformWorkloadIdentityProfile `json:"platformWorkloadIdentityProfile,omitempty"`
 
 	NetworkProfile NetworkProfile `json:"networkProfile,omitempty"`
 
@@ -228,6 +230,25 @@ type ServicePrincipalProfile struct {
 	ClientID     string       `json:"clientId,omitempty"`
 	ClientSecret SecureString `json:"clientSecret,omitempty"`
 	SPObjectID   string       `json:"spObjectId,omitempty"`
+}
+
+// PlatformWorkloadIdentityProfile encapsulates all information that is specific to workload identity clusters.
+type PlatformWorkloadIdentityProfile struct {
+	MissingFields
+
+	UpgradeableTo              *UpgradeableTo             `json:"upgradeableTo,omitempty" mutable:"true"`
+	PlatformWorkloadIdentities []PlatformWorkloadIdentity `json:"platformWorkloadIdentities,omitempty" mutable:"true"`
+}
+
+// UpgradeableTo stores a single OpenShift version a workload identity cluster can be upgraded to
+type UpgradeableTo string
+
+// PlatformWorkloadIdentity stores information representing a single workload identity.
+type PlatformWorkloadIdentity struct {
+	OperatorName string `json:"operatorName,omitempty" mutable:"true"`
+	ResourceID   string `json:"resourceId,omitempty" mutable:"true"`
+	ClientID     string `json:"clientId,omitempty" swagger:"readOnly" mutable:"true"`
+	ObjectID     string `json:"objectId,omitempty" swagger:"readOnly" mutable:"true"`
 }
 
 // SoftwareDefinedNetwork

--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -222,6 +222,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 						Architecture:   types.ArchitectureAMD64,
 					},
 				},
+				CredentialsMode: determineCredentialsMode(m.oc.Properties.PlatformWorkloadIdentityProfile),
 				Platform: types.Platform{
 					Azure: &azuretypes.Platform{
 						Region:                   strings.ToLower(m.oc.Location), // Used in k8s object names, so must pass DNS-1123 validation
@@ -317,4 +318,11 @@ func determineVMNetworkingType(vmSku *mgmtcompute.ResourceSku) string {
 		vmNetworkingType = azuretypes.VMNetworkingTypeBasic
 	}
 	return string(vmNetworkingType)
+}
+
+func determineCredentialsMode(pwip *api.PlatformWorkloadIdentityProfile) types.CredentialsMode {
+	if pwip != nil {
+		return types.ManualCredentialsMode
+	}
+	return types.PassthroughCredentialsMode
 }

--- a/pkg/installer/generateconfig_test.go
+++ b/pkg/installer/generateconfig_test.go
@@ -8,7 +8,10 @@ import (
 
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure"
+
+	"github.com/openshift/ARO-Installer/pkg/api"
 )
 
 func TestVMNetworkingType(t *testing.T) {
@@ -41,6 +44,34 @@ func TestVMNetworkingType(t *testing.T) {
 
 			if result != tt.wantType {
 				t.Error(result)
+			}
+		})
+	}
+}
+
+func TestDetermineCredentialsMode(t *testing.T) {
+	tt := []struct {
+		Name     string
+		PWIP     *api.PlatformWorkloadIdentityProfile
+		Expected types.CredentialsMode
+	}{
+		{
+			Name:     "profile specified",
+			PWIP:     &api.PlatformWorkloadIdentityProfile{},
+			Expected: types.ManualCredentialsMode,
+		},
+		{
+			Name:     "profile not specified",
+			PWIP:     nil,
+			Expected: types.PassthroughCredentialsMode,
+		},
+	}
+
+	for _, test := range tt {
+		t.Run(test.Name, func(t *testing.T) {
+			actual := determineCredentialsMode(test.PWIP)
+			if actual != test.Expected {
+				t.Errorf("got: %s, expected: %s", actual, test.Expected)
 			}
 		})
 	}


### PR DESCRIPTION
If a PlatformWorkloadIdentityProfile is specified, then set the credentials mode to "Manual" and if not, set the credentials mode to "Passthrough".

NB this also updates the ServicePrincipalProfile to be a pointer