### PR TITLE
ARO-6408 populate the CredentialsMode in the install config

### DIFF
--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -20,6 +20,7 @@ type OpenShiftCluster struct {
 	SystemData SystemData                 `json:"systemData,omitempty"`
 	Tags       map[string]string          `json:"tags,omitempty"`
 	Properties OpenShiftClusterProperties `json:"properties,omitempty"`
+	Identity   *Identity                  `json:"identity,omitempty"`
 }
 
 // CreatedByType by defines user type, which executed the request
@@ -116,7 +117,9 @@ type OpenShiftClusterProperties struct {
 
 	ConsoleProfile ConsoleProfile `json:"consoleProfile,omitempty"`
 
-	ServicePrincipalProfile ServicePrincipalProfile `json:"servicePrincipalProfile,omitempty"`
+	ServicePrincipalProfile *ServicePrincipalProfile `json:"servicePrincipalProfile,omitempty"`
+
+	PlatformWorkloadIdentityProfile *PlatformWorkloadIdentityProfile `json:"platformWorkloadIdentityProfile,omitempty"`
 
 	NetworkProfile NetworkProfile `json:"networkProfile,omitempty"`
 
@@ -228,6 +231,45 @@ type ServicePrincipalProfile struct {
 	ClientID     string       `json:"clientId,omitempty"`
 	ClientSecret SecureString `json:"clientSecret,omitempty"`
 	SPObjectID   string       `json:"spObjectId,omitempty"`
+}
+
+// PlatformWorkloadIdentityProfile encapsulates all information that is specific to workload identity clusters.
+type PlatformWorkloadIdentityProfile struct {
+	MissingFields
+
+	UpgradeableTo              *UpgradeableTo             `json:"upgradeableTo,omitempty" mutable:"true"`
+	PlatformWorkloadIdentities []PlatformWorkloadIdentity `json:"platformWorkloadIdentities,omitempty" mutable:"true"`
+}
+
+// UpgradeableTo stores a single OpenShift version a workload identity cluster can be upgraded to
+type UpgradeableTo string
+
+// PlatformWorkloadIdentity stores information representing a single workload identity.
+type PlatformWorkloadIdentity struct {
+	OperatorName string `json:"operatorName,omitempty" mutable:"true"`
+	ResourceID   string `json:"resourceId,omitempty" mutable:"true"`
+	ClientID     string `json:"clientId,omitempty" swagger:"readOnly" mutable:"true"`
+	ObjectID     string `json:"objectId,omitempty" swagger:"readOnly" mutable:"true"`
+}
+
+// ClusterUserAssignedIdentity stores information about a user-assigned managed identity in a predefined format required by Microsoft's Managed Identity team.
+type ClusterUserAssignedIdentity struct {
+	MissingFields
+
+	ClientID    string `json:"clientId,omitempty"`
+	PrincipalID string `json:"principalId,omitempty"`
+}
+
+// UserAssignedIdentities stores a mapping from resource IDs of managed identities to their client/principal IDs.
+type UserAssignedIdentities map[string]ClusterUserAssignedIdentity
+
+// Identity stores information about the cluster MSI(s) in a workload identity cluster.
+type Identity struct {
+	MissingFields
+
+	Type                   string                 `json:"type,omitempty"`
+	UserAssignedIdentities UserAssignedIdentities `json:"userAssignedIdentities,omitempty"`
+	IdentityURL            string                 `json:"identityURL,omitempty" mutable:"true"`
 }
 
 // SoftwareDefinedNetwork

--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -291,6 +291,10 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 		installConfig.Config.Publish = types.InternalPublishingStrategy
 	}
 
+	if m.oc.Properties.PlatformWorkloadIdentityProfile != nil && m.oc.Properties.ServicePrincipalProfile == nil {
+		installConfig.Config.CredentialsMode = types.ManualCredentialsMode
+	}
+
 	releaseImageOverride := os.Getenv("OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE")
 	if releaseImageOverride == "" {
 		return nil, nil, fmt.Errorf("no release image in 'OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE'")


### PR DESCRIPTION
If a PlatformWorkloadIdentityProfile is specified, then set the credentials mode to "Manual" and if not, set the credentials mode to "Passthrough".

NB this also updates the ServicePrincipalProfile to be a pointer