### PR TITLE
Explicitly convert zone definition for master VMs to string

### DIFF
--- a/pkg/installer/deployresources.go
+++ b/pkg/installer/deployresources.go
@@ -80,7 +80,7 @@ func zones(installConfig *installconfig.InstallConfig) (zones *[]string, err err
 	} else if zoneCount <= 2 {
 		zones = &installConfig.Config.ControlPlane.Platform.Azure.Zones
 	} else {
-		zones = &[]string{"[copyIndex(1)]"}
+		zones = &[]string{"[string(copyIndex(1))]"}
 	}
 
 	return

--- a/pkg/installer/deployresources_test.go
+++ b/pkg/installer/deployresources_test.go
@@ -45,7 +45,7 @@ func TestZones(t *testing.T) {
 		{
 			name:       "3 zones, 3 replicas",
 			zones:      []string{"1", "2", "3"},
-			wantMaster: &[]string{"[copyIndex(1)]"},
+			wantMaster: &[]string{"[string(copyIndex(1))]"},
 		},
 		{
 			name:    "4 zones, 3 replicas",


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes no Jira yet

### What this PR does / why we need it:

Explicitly converts zones passed in for the master VMs to ARM to string. This defends us from any ARM behavioral changes causing these values to render as integers (which are not supported for this field)

### Test plan for issue:

- [X] Updated unit tests pass
- [x] Cluster installations still work with this change

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

Tests performed above should validate that this results in a valid ARM template. 
