### PR TITLE
[4.14] bump installer-aro

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -588,11 +588,11 @@ replace (
 	github.com/openshift/cluster-api-provider-libvirt => github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20230929162348-34dfccba84a2
 	github.com/openshift/cluster-api-provider-ovirt => github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20230728074040-5d708631fca3
 	github.com/openshift/console-operator => github.com/openshift/console-operator v0.0.0-20220902005223-378917170147
-	github.com/openshift/installer => github.com/openshift/installer-aro v0.9.0-master.0.20240625232813-f4a9f6b0b313
+	github.com/openshift/installer => github.com/openshift/installer-aro v0.9.0-master.0.20240705142628-6986a1596809
 	github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20221018134251-bdb4fc834221
 	github.com/openshift/machine-api-operator => github.com/openshift/machine-api-operator v0.2.1-0.20220124104622-668c5b52b104
 	github.com/openshift/machine-api-provider-ibmcloud => github.com/openshift/machine-api-provider-ibmcloud v0.0.0-20230627135745-c28b2232ab1c
-	github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20240702202103-442bca4ab0d6
+	github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20240705011043-cee84af27d7c
 	github.com/oras-project/oras-go => oras.land/oras-go v0.4.0
 	github.com/ovirt/go-ovirt => github.com/ovirt/go-ovirt v0.0.0-20210112072624-e4d3b104de71
 	github.com/prometheus/prometheus => github.com/prometheus/prometheus v1.8.2-0.20210421143221-52df5ef7a3be

--- a/go.sum
+++ b/go.sum
@@ -1626,12 +1626,12 @@ github.com/openshift/custom-resource-status v1.1.2 h1:C3DL44LEbvlbItfd8mT5jWrqPf
 github.com/openshift/custom-resource-status v1.1.2/go.mod h1:DB/Mf2oTeiAmVVX1gN+NEqweonAPY0TKUwADizj8+ZA=
 github.com/openshift/hive/apis v0.0.0-20220719141355-c63c9b0281d8 h1:7e4sMDIstjEKW6SmPv8VhusDaYinDBrspd1M7ybIHC8=
 github.com/openshift/hive/apis v0.0.0-20220719141355-c63c9b0281d8/go.mod h1:XWo9dsulk75E9xkfxS/GNpJrL5UHgn3wuSyPeO39NME=
-github.com/openshift/installer-aro v0.9.0-master.0.20240625232813-f4a9f6b0b313 h1:6OvozZydmDJ4eiZxZqPzb8uLjxq7BtMH0JXg0bovoqk=
-github.com/openshift/installer-aro v0.9.0-master.0.20240625232813-f4a9f6b0b313/go.mod h1:Q3+OPKBEvTOVuAusxUlLr6h6+39GIXgjgQN4fZ3fov8=
+github.com/openshift/installer-aro v0.9.0-master.0.20240705142628-6986a1596809 h1:1AJyIdcxTCHI34XirpDYEDV61dyeWSSyNRbGT3IB/74=
+github.com/openshift/installer-aro v0.9.0-master.0.20240705142628-6986a1596809/go.mod h1:Q3+OPKBEvTOVuAusxUlLr6h6+39GIXgjgQN4fZ3fov8=
 github.com/openshift/machine-api-provider-ibmcloud v0.0.0-20230627135745-c28b2232ab1c h1:M6Dz5vloFwB0irrha8h7CEVugrPAK1nqrsVNXcvqoYU=
 github.com/openshift/machine-api-provider-ibmcloud v0.0.0-20230627135745-c28b2232ab1c/go.mod h1:/vPV5egjVdqN446z3WSgE0i79H6Gj+Xx85zG/k/Vl7Y=
-github.com/openshift/machine-config-operator v0.0.1-0.20240702202103-442bca4ab0d6 h1:94RlQ8HyX+BVjqt6ShkKemHWP6RGvu93HHxxmqU4W2k=
-github.com/openshift/machine-config-operator v0.0.1-0.20240702202103-442bca4ab0d6/go.mod h1:RVXxGeaeKYcdekIFMn640nvX1jxl/B8orgVssAneCsA=
+github.com/openshift/machine-config-operator v0.0.1-0.20240705011043-cee84af27d7c h1:LsdU63qZcXCpnIedISFARz3xMt1mEWhCE5lSpB7R35U=
+github.com/openshift/machine-config-operator v0.0.1-0.20240705011043-cee84af27d7c/go.mod h1:RVXxGeaeKYcdekIFMn640nvX1jxl/B8orgVssAneCsA=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b h1:FfH+VrHHk6Lxt9HdVS0PXzSXFyS2NbZKXv33FYPol0A=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b/go.mod h1:AC62GU6hc0BrNm+9RK9VSiwa/EUe1bkIeFORAMcHvJU=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1200,7 +1200,7 @@ github.com/openshift/hive/apis/hive/v1/openstack
 github.com/openshift/hive/apis/hive/v1/ovirt
 github.com/openshift/hive/apis/hive/v1/vsphere
 github.com/openshift/hive/apis/scheme
-# github.com/openshift/installer v0.16.1 => github.com/openshift/installer-aro v0.9.0-master.0.20240625232813-f4a9f6b0b313
+# github.com/openshift/installer v0.16.1 => github.com/openshift/installer-aro v0.9.0-master.0.20240705142628-6986a1596809
 ## explicit; go 1.20
 github.com/openshift/installer/data
 github.com/openshift/installer/pkg/aro/dnsmasq
@@ -1348,7 +1348,7 @@ github.com/openshift/installer/pkg/version
 ## explicit; go 1.19
 github.com/openshift/machine-api-provider-ibmcloud/pkg/apis
 github.com/openshift/machine-api-provider-ibmcloud/pkg/apis/ibmcloudprovider/v1
-# github.com/openshift/machine-config-operator v3.11.0+incompatible => github.com/openshift/machine-config-operator v0.0.1-0.20240702202103-442bca4ab0d6
+# github.com/openshift/machine-config-operator v3.11.0+incompatible => github.com/openshift/machine-config-operator v0.0.1-0.20240705011043-cee84af27d7c
 ## explicit; go 1.20
 github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1
 # github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b
@@ -2465,11 +2465,11 @@ sigs.k8s.io/yaml/goyaml.v2
 # github.com/openshift/cluster-api-provider-libvirt => github.com/openshift/cluster-api-provider-libvirt v0.2.1-0.20230929162348-34dfccba84a2
 # github.com/openshift/cluster-api-provider-ovirt => github.com/openshift/cluster-api-provider-ovirt v0.1.1-0.20230728074040-5d708631fca3
 # github.com/openshift/console-operator => github.com/openshift/console-operator v0.0.0-20220902005223-378917170147
-# github.com/openshift/installer => github.com/openshift/installer-aro v0.9.0-master.0.20240625232813-f4a9f6b0b313
+# github.com/openshift/installer => github.com/openshift/installer-aro v0.9.0-master.0.20240705142628-6986a1596809
 # github.com/openshift/library-go => github.com/openshift/library-go v0.0.0-20221018134251-bdb4fc834221
 # github.com/openshift/machine-api-operator => github.com/openshift/machine-api-operator v0.2.1-0.20220124104622-668c5b52b104
 # github.com/openshift/machine-api-provider-ibmcloud => github.com/openshift/machine-api-provider-ibmcloud v0.0.0-20230627135745-c28b2232ab1c
-# github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20240702202103-442bca4ab0d6
+# github.com/openshift/machine-config-operator => github.com/openshift/machine-config-operator v0.0.1-0.20240705011043-cee84af27d7c
 # github.com/oras-project/oras-go => oras.land/oras-go v0.4.0
 # github.com/ovirt/go-ovirt => github.com/ovirt/go-ovirt v0.0.0-20210112072624-e4d3b104de71
 # github.com/prometheus/prometheus => github.com/prometheus/prometheus v1.8.2-0.20210421143221-52df5ef7a3be


### PR DESCRIPTION
bumping installer-aro.

installer-aro is updated because of OWNER change. https://github.com/openshift/installer-aro/pull/30