### PR TITLE
function to check if a cluster is workload identity or service principal

### DIFF
--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -468,3 +468,8 @@ type HiveProfile struct {
 
 	Namespace string `json:"namespace,omitempty"`
 }
+
+// IsWorkloadIdentity checks whether a cluster is a Workload Identity cluster or Service Principal cluster
+func (oc *OpenShiftCluster) IsWorkloadIdentity() bool {
+	return oc.Properties.PlatformWorkloadIdentityProfile != nil && oc.Properties.ServicePrincipalProfile == nil
+}

--- a/pkg/api/openshiftcluster_test.go
+++ b/pkg/api/openshiftcluster_test.go
@@ -3,7 +3,10 @@ package api
 // Copyright (c) Microsoft Corporation.
 // Licensed under the Apache License 2.0.
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestIsTerminal(t *testing.T) {
 	for _, tt := range []struct {
@@ -45,6 +48,64 @@ func TestIsTerminal(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.state.IsTerminal() != tt.want {
 				t.Fatalf("%s isTerminal wants != %t", tt.state, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsWorkloadIdentity(t *testing.T) {
+	tests := []*struct {
+		name string
+		oc   OpenShiftCluster
+		want bool
+	}{
+		{
+			name: "Cluster is Workload Identity",
+			oc: OpenShiftCluster{
+				Properties: OpenShiftClusterProperties{
+					PlatformWorkloadIdentityProfile: &PlatformWorkloadIdentityProfile{},
+					ServicePrincipalProfile:         nil,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Cluster is Service Principal",
+			oc: OpenShiftCluster{
+				Properties: OpenShiftClusterProperties{
+					PlatformWorkloadIdentityProfile: nil,
+					ServicePrincipalProfile:         &ServicePrincipalProfile{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Cluster is Service Principal",
+			oc: OpenShiftCluster{
+				Properties: OpenShiftClusterProperties{
+					PlatformWorkloadIdentityProfile: nil,
+					ServicePrincipalProfile:         nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Cluster is Service Principal",
+			oc: OpenShiftCluster{
+				Properties: OpenShiftClusterProperties{
+					PlatformWorkloadIdentityProfile: &PlatformWorkloadIdentityProfile{},
+					ServicePrincipalProfile:         &ServicePrincipalProfile{},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.oc.IsWorkloadIdentity()
+			if got != test.want {
+				t.Error(fmt.Errorf("got != want: %v != %v", got, test.want))
 			}
 		})
 	}

--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -293,7 +293,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 		installConfig.Config.Publish = types.InternalPublishingStrategy
 	}
 
-	if m.oc.Properties.PlatformWorkloadIdentityProfile != nil && m.oc.Properties.ServicePrincipalProfile == nil {
+	if m.oc.IsWorkloadIdentity() {
 		installConfig.Config.CredentialsMode = types.ManualCredentialsMode
 	}
 


### PR DESCRIPTION
Which issue this PR addresses:
[ARO-7856](https://issues.redhat.com/browse/ARO-7856)

What this PR does / why we need it:
Throughout the RP codebase and installer wrapper, we are using if platformworkloadidentityprofile != nil to indicate whether or not a cluster is workload identity or not. This PR includes a shared utility function to check if a function is Workload Identity or Classic, which can be imported in all parts of the codebase.