### PR TITLE
Stop yum update

### DIFF
--- a/Dockerfile.aro
+++ b/Dockerfile.aro
@@ -6,7 +6,6 @@ ENV GOOS=linux \
     GOPATH=/go/
 WORKDIR ${GOPATH}/src/github.com/openshift/installer-aro-wrapper
 USER root
-RUN yum update -y
 COPY . ${GOPATH}/src/github.com/openshift/installer-aro-wrapper/
 RUN git config --system --add safe.directory '*'
 RUN make aro


### PR DESCRIPTION
Because it runs `yum update`, it doesn't respect the image's default go version.

The package versions should be managed within the base image, we don't need to update them here.