### PR TITLE
ARO-4518 read custom manifests from hive created volume to persist in cluster graph 

### DIFF
--- a/pkg/installer/aromanifests.go
+++ b/pkg/installer/aromanifests.go
@@ -1,0 +1,94 @@
+package installer
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/openshift/installer/pkg/asset"
+	"github.com/pkg/errors"
+)
+
+const (
+	aroManifestDir = "manifests"
+)
+
+type AROManifests struct {
+	FileList []*asset.File
+}
+
+type aroFileFetcher struct {
+	directory string
+}
+
+var (
+	_ asset.WritableAsset = (*AROManifests)(nil)
+	_ asset.FileFetcher   = (*aroFileFetcher)(nil)
+)
+
+func (am *AROManifests) Name() string {
+	return "ARO Manifests"
+}
+
+func (am *AROManifests) Dependencies() []asset.Asset {
+	return []asset.Asset{}
+}
+
+func (am *AROManifests) Generate(dependencies asset.Parents) error {
+	return nil
+}
+
+func (am *AROManifests) Files() []*asset.File {
+	return am.FileList
+}
+
+func (am *AROManifests) Load(f asset.FileFetcher) (found bool, err error) {
+	yamlFileList, err := f.FetchByPattern(filepath.Join(aroManifestDir, "*.yaml"))
+	if err != nil {
+		return false, errors.Wrap(err, "failed to load *.yaml files")
+	}
+	ymlFileList, err := f.FetchByPattern(filepath.Join(aroManifestDir, "*.yml"))
+	if err != nil {
+		return false, errors.Wrap(err, "failed to load *.yml files")
+	}
+
+	am.FileList = append(am.FileList, yamlFileList...)
+	am.FileList = append(am.FileList, ymlFileList...)
+	asset.SortFiles(am.FileList)
+
+	return len(am.FileList) > 0, nil
+}
+
+func (f *aroFileFetcher) FetchByName(name string) (*asset.File, error) {
+	data, err := os.ReadFile(filepath.Join(f.directory, name))
+	if err != nil {
+		return nil, err
+	}
+	return &asset.File{Filename: name, Data: data}, nil
+}
+
+func (f *aroFileFetcher) FetchByPattern(pattern string) (files []*asset.File, err error) {
+	matches, err := filepath.Glob(filepath.Join(f.directory, pattern))
+	if err != nil {
+		return nil, err
+	}
+
+	files = make([]*asset.File, 0, len(matches))
+	for _, path := range matches {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+
+		filename, err := filepath.Rel(f.directory, path)
+		if err != nil {
+			return nil, err
+		}
+
+		files = append(files, &asset.File{
+			Filename: filename,
+			Data:     data,
+		})
+	}
+
+	return files, nil
+}

--- a/pkg/installer/custominstallconfig.go
+++ b/pkg/installer/custominstallconfig.go
@@ -53,8 +53,17 @@ func (m *manager) applyInstallConfigCustomisations(installConfig *installconfig.
 		dnsConfig.GatewayDomains = append(m.env.GatewayDomains(), m.oc.Properties.ImageRegistryStorageAccountName+".blob."+m.env.Environment().StorageEndpointSuffix)
 	}
 
+	aroManifests := &AROManifests{}
+	fileFetcher := &aroFileFetcher{directory: "/"}
+	if found, err := aroManifests.Load(fileFetcher); err != nil {
+		m.log.Errorf("Error loading ARO manifests: %v", err)
+		return nil, err
+	} else {
+		m.log.Infof("Found ARO manifests: %v, %d", found, len(aroManifests.FileList))
+	}
+
 	g := graph.Graph{}
-	g.Set(installConfig, image, clusterID, bootstrapLoggingConfig, dnsConfig, imageRegistryConfig)
+	g.Set(installConfig, image, clusterID, bootstrapLoggingConfig, dnsConfig, imageRegistryConfig, aroManifests)
 
 	m.log.Print("resolving graph")
 	for _, a := range targets.Cluster {

--- a/pkg/installer/custominstallconfig.go
+++ b/pkg/installer/custominstallconfig.go
@@ -55,15 +55,14 @@ func (m *manager) applyInstallConfigCustomisations(installConfig *installconfig.
 
 	aroManifests := &AROManifests{}
 	fileFetcher := &aroFileFetcher{directory: "/"}
-	if found, err := aroManifests.Load(fileFetcher); err != nil {
+	aroManifestsExist, err := aroManifests.Load(fileFetcher)
+	if err != nil {
 		m.log.Errorf("Error loading ARO manifests: %v", err)
 		return nil, err
-	} else {
-		m.log.Infof("Found ARO manifests: %v, %d", found, len(aroManifests.FileList))
 	}
 
 	g := graph.Graph{}
-	g.Set(installConfig, image, clusterID, bootstrapLoggingConfig, dnsConfig, imageRegistryConfig, aroManifests)
+	g.Set(installConfig, image, clusterID, bootstrapLoggingConfig, dnsConfig, imageRegistryConfig)
 
 	m.log.Print("resolving graph")
 	for _, a := range targets.Cluster {
@@ -77,6 +76,13 @@ func (m *manager) applyInstallConfigCustomisations(installConfig *installconfig.
 	if m.oc.Properties.NetworkProfile.MTUSize == api.MTU3900 {
 		m.log.Printf("applying feature flag %s", api.FeatureFlagMTU3900)
 		if err = m.overrideEthernetMTU(g); err != nil {
+			return nil, err
+		}
+	}
+
+	// Add ARO Manifests to bootstrap Files
+	if aroManifestsExist {
+		if err = aroManifests.AppendFilesToBootstrap(g); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -277,16 +277,6 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 					},
 				},
 			}},
-		Azure: icazure.NewMetadataWithCredentials(
-			azuretypes.CloudEnvironment(m.env.Environment().Name),
-			m.env.Environment().ResourceManagerEndpoint,
-			&icazure.Credentials{
-				TenantID:       m.sub.Properties.TenantID,
-				ClientID:       m.oc.Properties.ServicePrincipalProfile.ClientID,
-				ClientSecret:   string(m.oc.Properties.ServicePrincipalProfile.ClientSecret),
-				SubscriptionID: r.SubscriptionID,
-			},
-		),
 	}
 
 	if m.oc.Properties.IngressProfiles[0].Visibility == api.VisibilityPrivate {
@@ -295,6 +285,17 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 
 	if m.oc.UsesWorkloadIdentity() {
 		installConfig.Config.CredentialsMode = types.ManualCredentialsMode
+	} else {
+		installConfig.Azure = icazure.NewMetadataWithCredentials(
+			azuretypes.CloudEnvironment(m.env.Environment().Name),
+			m.env.Environment().ResourceManagerEndpoint,
+			&icazure.Credentials{
+				TenantID:       m.sub.Properties.TenantID,
+				ClientID:       m.oc.Properties.ServicePrincipalProfile.ClientID,
+				ClientSecret:   string(m.oc.Properties.ServicePrincipalProfile.ClientSecret),
+				SubscriptionID: r.SubscriptionID,
+			},
+		)
 	}
 
 	releaseImageOverride := os.Getenv("OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE")


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes (https://issues.redhat.com/browse/ARO-4518)

### What this PR does / why we need it:

- Read manifests from `/manifests` folder created by hive when triggering the installer pod. Manifests are passed from ARO-RP - https://github.com/Azure/ARO-RP/pull/3841 
- Persist all the found manifests to the ARO Cluster graph
- Handle the Azure credentials in install-config based on the type of cluster, miwi vs non-miwi

### Test plan for issue:
- [x] Local cluster installation using the installer-wrapper PR https://github.com/Azure/ARO-RP/pull/3841

### Is there any documentation that needs to be updated for this PR?

No.
Please suggest if there's any documentation that needs updating.

### How do you know this will function as expected in production? 

- For non-miwi clusters, tested the the cluster creation flow.
- Custom Manifests creation is tested successfully in combination with the ARO-RP PR:- https://github.com/Azure/ARO-RP/pull/3841