### PR TITLE
Increase bootstrapConfigMapReady condition check timeout to 60 minutes

### DIFF
--- a/pkg/installer/install.go
+++ b/pkg/installer/install.go
@@ -53,7 +53,7 @@ func (m *manager) Install(ctx context.Context) error {
 	s := []steps.Step{
 		steps.AuthorizationRetryingAction(m.fpAuthorizer, m.deployResourceTemplate),
 		steps.Action(m.initializeKubernetesClients),
-		steps.Condition(m.bootstrapConfigMapReady, 30*time.Minute, true),
+		steps.Condition(m.bootstrapConfigMapReady, 60*time.Minute, true),
 	}
 
 	err := steps.Run(ctx, m.log, 10*time.Second, s)


### PR DESCRIPTION
Increase the wait for "bootstrap complete" to 60 minutes.

We've observed a number of ARO cluster install failures where the cluster eventually had a "complete" bootstrap CM present on the APIserver very shortly after the existing 30minute timeout was hit, resulting in "failed" cluster installs for otherwise-healthy clusters.
