### PR TITLE
ARO-4374 append signing account key to the graph for the installer to use

### DIFF
--- a/pkg/api/openshiftcluster.go
+++ b/pkg/api/openshiftcluster.go
@@ -203,11 +203,12 @@ const (
 type ClusterProfile struct {
 	MissingFields
 
-	PullSecret           SecureString         `json:"pullSecret,omitempty"`
-	Domain               string               `json:"domain,omitempty"`
-	Version              string               `json:"version,omitempty"`
-	ResourceGroupID      string               `json:"resourceGroupId,omitempty"`
-	FipsValidatedModules FipsValidatedModules `json:"fipsValidatedModules,omitempty"`
+	PullSecret                    SecureString         `json:"pullSecret,omitempty"`
+	Domain                        string               `json:"domain,omitempty"`
+	Version                       string               `json:"version,omitempty"`
+	ResourceGroupID               string               `json:"resourceGroupId,omitempty"`
+	FipsValidatedModules          FipsValidatedModules `json:"fipsValidatedModules,omitempty"`
+	BoundServiceAccountSigningKey *SecureString        `json:"boundServiceAccountSigningKey,omitempty"`
 }
 
 // FeatureProfile represents a feature profile.


### PR DESCRIPTION
This will allow the API server to use the private key to start operators on clusters using workload identity