### PR TITLE
For miwi use user delegated sas to allow bootstrap node to pull the ignition

### DIFF
--- a/pkg/installer/deployresources_resources.go
+++ b/pkg/installer/deployresources_resources.go
@@ -100,14 +100,14 @@ func (m *manager) networkMasterNICs(installConfig *installconfig.InstallConfig) 
 func (m *manager) computeBootstrapVM(installConfig *installconfig.InstallConfig) *arm.Resource {
 	var customData, sasURL string
 	if m.oc.UsesWorkloadIdentity() {
-		sasURL = `"replace":{"source":"parameters('sas')"`
+		sasURL = `',parameters('sas'),'`
 	} else {
-		sasURL = `"replace":{"source":"https://cluster` + m.oc.Properties.StorageSuffix + `.blob.` + m.env.Environment().StorageEndpointSuffix + `/ignition/bootstrap.ign?', listAccountSas(resourceId('Microsoft.Storage/storageAccounts', 'cluster` + m.oc.Properties.StorageSuffix + `'), '2019-04-01', parameters('sas')).accountSasToken, '"`
+		sasURL = `"https://cluster` + m.oc.Properties.StorageSuffix + `.blob.` + m.env.Environment().StorageEndpointSuffix + `/ignition/bootstrap.ign?', listAccountSas(resourceId('Microsoft.Storage/storageAccounts', 'cluster` + m.oc.Properties.StorageSuffix + `'), '2019-04-01', parameters('sas')).accountSasToken, '`
 	}
 	if m.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP != "" {
-		customData = `[base64(concat('{"ignition":{"version":"3.2.0","proxy":{"httpsProxy":"http://` + m.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP + `"},"config":{` + sasURL + `}}}}'))]`
+		customData = `[base64(concat('{"ignition":{"version":"3.2.0","proxy":{"httpsProxy":"http://` + m.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP + `"},"config":{"replace":{"source":"` + sasURL + `"}}}}'))]`
 	} else {
-		customData = `[base64(concat('{"ignition":{"version":"3.2.0","config":{` + sasURL + `}}}}'))]`
+		customData = `[base64(concat('{"ignition":{"version":"3.2.0","config":{"replace":{"source":"` + sasURL + `"}}}}'))]`
 	}
 
 	vm := &mgmtcompute.VirtualMachine{

--- a/pkg/installer/deployresources_resources.go
+++ b/pkg/installer/deployresources_resources.go
@@ -98,11 +98,16 @@ func (m *manager) networkMasterNICs(installConfig *installconfig.InstallConfig) 
 }
 
 func (m *manager) computeBootstrapVM(installConfig *installconfig.InstallConfig) *arm.Resource {
-	var customData string
-	if m.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP != "" {
-		customData = `[base64(concat('{"ignition":{"version":"3.2.0","proxy":{"httpsProxy":"http://` + m.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP + `"},"config":{"replace":{"source":"https://cluster` + m.oc.Properties.StorageSuffix + `.blob.` + m.env.Environment().StorageEndpointSuffix + `/ignition/bootstrap.ign?', listAccountSas(resourceId('Microsoft.Storage/storageAccounts', 'cluster` + m.oc.Properties.StorageSuffix + `'), '2019-04-01', parameters('sas')).accountSasToken, '"}}}}'))]`
+	var customData, sasURL string
+	if m.oc.UsesWorkloadIdentity() {
+		sasURL = `"replace":{"source":"parameters('sas')"`
 	} else {
-		customData = `[base64(concat('{"ignition":{"version":"3.2.0","config":{"replace":{"source":"https://cluster` + m.oc.Properties.StorageSuffix + `.blob.` + m.env.Environment().StorageEndpointSuffix + `/ignition/bootstrap.ign?', listAccountSas(resourceId('Microsoft.Storage/storageAccounts', 'cluster` + m.oc.Properties.StorageSuffix + `'), '2019-04-01', parameters('sas')).accountSasToken, '"}}}}'))]`
+		sasURL = `"replace":{"source":"https://cluster` + m.oc.Properties.StorageSuffix + `.blob.` + m.env.Environment().StorageEndpointSuffix + `/ignition/bootstrap.ign?', listAccountSas(resourceId('Microsoft.Storage/storageAccounts', 'cluster` + m.oc.Properties.StorageSuffix + `'), '2019-04-01', parameters('sas')).accountSasToken, '"`
+	}
+	if m.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP != "" {
+		customData = `[base64(concat('{"ignition":{"version":"3.2.0","proxy":{"httpsProxy":"http://` + m.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP + `"},"config":{` + sasURL + `}}}}'))]`
+	} else {
+		customData = `[base64(concat('{"ignition":{"version":"3.2.0","config":{` + sasURL + `}}}}'))]`
 	}
 
 	vm := &mgmtcompute.VirtualMachine{

--- a/pkg/installer/deployresources_resources.go
+++ b/pkg/installer/deployresources_resources.go
@@ -102,7 +102,7 @@ func (m *manager) computeBootstrapVM(installConfig *installconfig.InstallConfig)
 	if m.oc.UsesWorkloadIdentity() {
 		sasURL = `',parameters('sas'),'`
 	} else {
-		sasURL = `"https://cluster` + m.oc.Properties.StorageSuffix + `.blob.` + m.env.Environment().StorageEndpointSuffix + `/ignition/bootstrap.ign?', listAccountSas(resourceId('Microsoft.Storage/storageAccounts', 'cluster` + m.oc.Properties.StorageSuffix + `'), '2019-04-01', parameters('sas')).accountSasToken, '`
+		sasURL = `https://cluster` + m.oc.Properties.StorageSuffix + `.blob.` + m.env.Environment().StorageEndpointSuffix + `/ignition/bootstrap.ign?', listAccountSas(resourceId('Microsoft.Storage/storageAccounts', 'cluster` + m.oc.Properties.StorageSuffix + `'), '2019-04-01', parameters('sas')).accountSasToken, '`
 	}
 	if m.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP != "" {
 		customData = `[base64(concat('{"ignition":{"version":"3.2.0","proxy":{"httpsProxy":"http://` + m.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP + `"},"config":{"replace":{"source":"` + sasURL + `"}}}}'))]`

--- a/pkg/util/azureclient/azuresdk/azblob/blobs.go
+++ b/pkg/util/azureclient/azuresdk/azblob/blobs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
 )
 
 // BlobsClient is a minimal interface for Azure BlobsClient
@@ -16,6 +17,7 @@ type BlobsClient interface {
 	DownloadStream(ctx context.Context, containerName string, blobName string, o *azblob.DownloadStreamOptions) (azblob.DownloadStreamResponse, error)
 	UploadBuffer(ctx context.Context, containerName string, blobName string, buffer []byte, o *azblob.UploadBufferOptions) (azblob.UploadBufferResponse, error)
 	DeleteBlob(ctx context.Context, containerName string, blobName string, o *azblob.DeleteBlobOptions) (azblob.DeleteBlobResponse, error)
+	ServiceClient() *service.Client
 	BlobsClientAddons
 }
 

--- a/pkg/util/mocks/graph/graph.go
+++ b/pkg/util/mocks/graph/graph.go
@@ -51,6 +51,21 @@ func (mr *MockManagerMockRecorder) Exists(arg0, arg1, arg2 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockManager)(nil).Exists), arg0, arg1, arg2)
 }
 
+// GetUserDelegatedSASIgnitionBlobURL mocks base method.
+func (m *MockManager) GetUserDelegatedSASIgnitionBlobURL(arg0 context.Context, arg1, arg2, arg3 string, arg4 bool) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserDelegatedSASIgnitionBlobURL", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserDelegatedSASIgnitionBlobURL indicates an expected call of GetUserDelegatedSASIgnitionBlobURL.
+func (mr *MockManagerMockRecorder) GetUserDelegatedSASIgnitionBlobURL(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserDelegatedSASIgnitionBlobURL", reflect.TypeOf((*MockManager)(nil).GetUserDelegatedSASIgnitionBlobURL), arg0, arg1, arg2, arg3, arg4)
+}
+
 // LoadPersisted mocks base method.
 func (m *MockManager) LoadPersisted(arg0 context.Context, arg1, arg2 string) (graph.PersistedGraph, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### Which issue this PR addresses:
Fixes https://issues.redhat.com/browse/ARO-9712 in combination with ARO-RP PR:- https://github.com/Azure/ARO-RP/pull/3894
<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->

### What this PR does / why we need it:
For MIWI:
- Since the storage accounts Cluster will have the shared access keys disabled, the ListAccountSAS won't work, so instead of Account SAS, we need UserDelegatedSAS token to pull the ignition blob from the Cluster Storage Account

<!--
Include a brief summary of what the PR is intended to accomplish and how the PR
does it. (2-3 sentences)
-->

### Test plan for issue:
[x] Test the flow of cluster install such that the Shared Access Keys are disabled.
[x] Test the flow of cluster install such that the Cluster Service Principal Cluster are created correctly.
<!--
How did you test that this PR works?

- Are there unit tests?
- Are there integration/e2e tests?
- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.
-->

### Is there any documentation that needs to be updated for this PR?
No
<!--
- If yes and the docs are in GitHub, include doc updates in the PR.
- If yes and the docs are not in GitHub (i.e. ADO wiki), include a link to the
  docs.
- If no, explain why (e.g. "tech debt cleanup, N/A").
-->

### How do you know this will function as expected in production? 
- For non-MIWI cluster there's no functionality change
- For MIWI cluster the flow has been tested by reversing the usesWorkloadIdentity function. The whole flow can be tested once the feature is tested.
<!--
- Does adequate telemetry, monitoring and documentation exist to effectively operate your change?
- Have failure modes been identified and mitigated? 
-->

/cherrypick release-4.15 release-4.14
