### PR TITLE
[release-4.14] Pass the first party service principal certificate to install-config.yaml for MIWI clusters

### DIFF
--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -79,6 +79,7 @@ type Interface interface {
 	Domain() string
 	FeatureIsSet(Feature) bool
 	FPAuthorizer(string, ...string) (autorest.Authorizer, error)
+	FPCertificates() (*rsa.PrivateKey, []*x509.Certificate)
 	FPNewClientCertificateCredential(string) (*azidentity.ClientCertificateCredential, error)
 	FPClientID() string
 	Listen() (net.Listener, error)

--- a/pkg/env/prod.go
+++ b/pkg/env/prod.go
@@ -316,8 +316,12 @@ func (p *prod) FPAuthorizer(tenantID string, scopes ...string) (autorest.Authori
 	return azidext.NewTokenCredentialAdapter(tokenCredential, scopes), nil
 }
 
+func (p *prod) FPCertificates() (*rsa.PrivateKey, []*x509.Certificate) {
+	return p.fpCertificateRefresher.GetCertificates()
+}
+
 func (p *prod) FPNewClientCertificateCredential(tenantID string) (*azidentity.ClientCertificateCredential, error) {
-	fpPrivateKey, fpCertificates := p.fpCertificateRefresher.GetCertificates()
+	fpPrivateKey, fpCertificates := p.FPCertificates()
 	options := p.Environment().ClientCertificateCredentialOptions()
 	credential, err := azidentity.NewClientCertificateCredential(tenantID, p.fpClientID, fpCertificates, fpPrivateKey, options)
 	if err != nil {

--- a/pkg/util/pem/pem.go
+++ b/pkg/util/pem/pem.go
@@ -8,7 +8,12 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
+	"io"
 )
+
+type Encodable interface {
+	*x509.Certificate | *x509.CertificateRequest | *rsa.PublicKey | *rsa.PrivateKey
+}
 
 func Parse(b []byte) (key *rsa.PrivateKey, certs []*x509.Certificate, err error) {
 	for {
@@ -49,4 +54,39 @@ func Parse(b []byte) (key *rsa.PrivateKey, certs []*x509.Certificate, err error)
 	}
 
 	return key, certs, nil
+}
+
+func Encode[V Encodable](w io.Writer, inputs ...V) (err error) {
+	for _, cer := range inputs {
+		pemType := "UNKNOWN"
+		var rawBytes []byte
+
+		switch t := any(cer).(type) {
+		case *x509.Certificate:
+			pemType = "CERTIFICATE"
+			rawBytes = t.Raw
+		case *x509.CertificateRequest:
+			pemType = "CERTIFICATE REQUEST"
+			rawBytes = t.Raw
+		case *rsa.PrivateKey:
+			pemType = "RSA PRIVATE KEY"
+			rawBytes = x509.MarshalPKCS1PrivateKey(t)
+		case *rsa.PublicKey:
+			pemType = "RSA PUBLIC KEY"
+			rawBytes, err = x509.MarshalPKIXPublicKey(t)
+			if err != nil {
+				return
+			}
+		default:
+			err = fmt.Errorf("unable to identify %v", t)
+			return
+		}
+
+		err = pem.Encode(w, &pem.Block{Type: pemType, Bytes: rawBytes})
+		if err != nil {
+			return
+		}
+	}
+
+	return
 }

--- a/pkg/util/pem/pem_test.go
+++ b/pkg/util/pem/pem_test.go
@@ -1,0 +1,50 @@
+package pem
+
+import (
+	"bytes"
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	utiltls "github.com/openshift/ARO-Installer/pkg/util/tls"
+)
+
+func TestEncode(t *testing.T) {
+	validCaKey, validCaCerts, err := utiltls.GenerateKeyAndCertificate("validca", nil, nil, true, false)
+	assert.NoError(t, err)
+
+	t.Run("encoding key", func(t *testing.T) {
+		var b bytes.Buffer
+		err := Encode(&b, validCaKey)
+		if assert.NoError(t, err) {
+			assert.Regexp(t, regexp.MustCompile("-----BEGIN RSA PRIVATE KEY-----\n(?:[a-zA-Z0-9+/=]+\n)*-----END RSA PRIVATE KEY-----\n"), b.String())
+		}
+	})
+
+	t.Run("encoding single certificate", func(t *testing.T) {
+		var b bytes.Buffer
+		err := Encode(&b, validCaCerts[0])
+		if assert.NoError(t, err) {
+			assert.Regexp(t, regexp.MustCompile("-----BEGIN CERTIFICATE-----\n(?:[a-zA-Z0-9+/=]+\n)*-----END CERTIFICATE-----\n"), b.String())
+		}
+	})
+
+	t.Run("encoding multiple certificates", func(t *testing.T) {
+		var b bytes.Buffer
+		err := Encode(&b, validCaCerts[0], validCaCerts[0])
+		if assert.NoError(t, err) {
+			assert.Regexp(t, regexp.MustCompile("(?:-----BEGIN CERTIFICATE-----\n(?:[a-zA-Z0-9+/=]+\n)*-----END CERTIFICATE-----\n){2}"), b.String())
+		}
+	})
+
+	t.Run("encoding multiple certificates and private key", func(t *testing.T) {
+		var b bytes.Buffer
+		err := Encode(&b, validCaCerts[0], validCaCerts[0])
+		err = errors.Join(err, Encode(&b, validCaKey))
+		if assert.NoError(t, err) {
+			assert.Regexp(t, regexp.MustCompile("(?:-----BEGIN CERTIFICATE-----\n(?:[a-zA-Z0-9+/=]+\n)*-----END CERTIFICATE-----\n){2}-----BEGIN RSA PRIVATE KEY-----\n(?:[a-zA-Z0-9+/=]+\n)*-----END RSA PRIVATE KEY-----\n"), b.String())
+		}
+	})
+}


### PR DESCRIPTION
Manual cherry-pick of #189 to release-4.14, due to module name changes to this repository between 4.14 and 4.15 we cannot automatically cherry-pick this change. 