### PR TITLE
Add appendFilesToCvoOverrides step to inject AROManifests into CVO Overrides

### DIFF
--- a/hack/validate-imports/validate-imports.go
+++ b/hack/validate-imports/validate-imports.go
@@ -12,7 +12,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ghodss/yaml"
+	"sigs.k8s.io/yaml"
 )
 
 //go:embed allowed-import-names.yaml
@@ -218,8 +218,8 @@ func (validator importValidator) validateImport(imp *ast.ImportSpec) error {
 	}
 
 	switch packageName {
-	case "sigs.k8s.io/yaml", "gopkg.in/yaml.v2":
-		return fmt.Errorf("%s is imported; use github.com/ghodss/yaml", packageName)
+	case "github.com/ghodss/yaml", "gopkg.in/yaml.v2":
+		return fmt.Errorf("%s is imported; use sigs.k8s.io/yaml", packageName)
 	case "github.com/google/uuid", "github.com/satori/go.uuid":
 		return fmt.Errorf("%s is imported; use github.com/gofrs/uuid", packageName)
 	}

--- a/pkg/installer/custominstallconfig.go
+++ b/pkg/installer/custominstallconfig.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset"
 	"github.com/openshift/installer/pkg/asset/ignition"
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
@@ -16,10 +17,17 @@ import (
 	"github.com/openshift/installer/pkg/asset/releaseimage"
 	"github.com/openshift/installer/pkg/asset/targets"
 	"github.com/openshift/installer/pkg/asset/templates/content/bootkube"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/yaml"
 
 	"github.com/openshift/installer-aro-wrapper/pkg/api"
 	"github.com/openshift/installer-aro-wrapper/pkg/bootstraplogging"
 	"github.com/openshift/installer-aro-wrapper/pkg/cluster/graph"
+)
+
+const (
+	cvoOverridesFilename = "manifests/cvo-overrides.yaml"
 )
 
 // applyInstallConfigCustomisations modifies the InstallConfig and creates
@@ -95,8 +103,12 @@ func (m *manager) applyInstallConfigCustomisations(installConfig *installconfig.
 		}
 	}
 
-	// Add ARO Manifests to bootstrap Files
+	// Add ARO Manifests to bootstrap Files and CVO Overrides
 	if aroManifestsExist {
+		if err = appendFilesToCvoOverrides(aroManifests, g); err != nil {
+			return nil, err
+		}
+
 		if err = appendFilesToBootstrap(aroManifests, g); err != nil {
 			return nil, err
 		}
@@ -117,5 +129,78 @@ func appendFilesToBootstrap(a asset.WritableAsset, g graph.Graph) error {
 		return err
 	}
 	bootstrap.File.Data = data
+	return nil
+}
+
+// appendFilesToCvoOverides performs the same functionality as the upstream
+// installer's CVOIgnore asset (pkg/asset/ignition/bootstrap/cvoignore.go),
+// but for our custom AROManifests asset.
+func appendFilesToCvoOverrides(a asset.WritableAsset, g graph.Graph) (err error) {
+	cvoIgnore := g.Get(&bootstrap.CVOIgnore{}).(*bootstrap.CVOIgnore)
+	bootstrap := g.Get(&bootstrap.Bootstrap{}).(*bootstrap.Bootstrap)
+
+	var ignoredResources []configv1.ComponentOverride
+	files := a.Files()
+	seen := make(map[string]string, len(files))
+
+	for _, file := range files {
+		u := &unstructured.Unstructured{}
+		if err := yaml.Unmarshal(file.Data, u); err != nil {
+			return errors.Wrapf(err, "could not unmarshal %q", file.Filename)
+		}
+
+		group := u.GetObjectKind().GroupVersionKind().Group
+		kind := u.GetKind()
+		namespace := u.GetNamespace()
+		name := u.GetName()
+
+		key := fmt.Sprintf("%s |! %s |! %s |! %s", group, kind, namespace, name)
+		if previousFile, ok := seen[key]; ok {
+			return fmt.Errorf("multiple manifests for group %s kind %s namespace %s name %s: %s, %s", group, kind, namespace, name, previousFile, file.Filename)
+		}
+		seen[key] = file.Filename
+
+		ignoredResources = append(ignoredResources,
+			configv1.ComponentOverride{
+				Kind:      kind,
+				Group:     group,
+				Namespace: namespace,
+				Name:      name,
+				Unmanaged: true,
+			})
+	}
+
+	clusterVersion := &configv1.ClusterVersion{}
+	var cvData []byte
+	for i, file := range cvoIgnore.Files() {
+		if file.Filename != cvoOverridesFilename {
+			continue
+		}
+
+		if err := yaml.Unmarshal(file.Data, clusterVersion); err != nil {
+			return errors.Wrapf(err, "could not unmarshal %q", file.Filename)
+		}
+
+		clusterVersion.Spec.Overrides = append(clusterVersion.Spec.Overrides, ignoredResources...)
+
+		cvData, err = yaml.Marshal(clusterVersion)
+		if err != nil {
+			return errors.Wrap(err, "error marshalling clusterversion")
+		}
+		cvoIgnore.FileList[i] = &asset.File{
+			Filename: file.Filename,
+			Data:     cvData,
+		}
+	}
+
+	ignPath := filepath.Join(rootPath, cvoOverridesFilename)
+	for i, file := range bootstrap.Config.Storage.Files {
+		if file.Path != ignPath {
+			continue
+		}
+
+		bootstrap.Config.Storage.Files[i] = ignition.FileFromBytes(ignPath, "root", 0420, cvData)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Append all custom "AROManifests" to the clusterversion's "overrides" list - this will ensure that CVO will not attempt to put down resources we define in custom manifests. 

This implementation duplicates the functionality performed by the upstream installer's CVOIgnore asset for the upstream Manifests assets, though just for our custom AROManifests asset: https://github.com/openshift/installer/blob/release-4.14/pkg/asset/ignition/bootstrap/cvoignore.go

/cherrypick release-4.15 release-4.14 