### PR TITLE
Use managed boot diagnostics for bootstrap and master VMs

### DIFF
--- a/pkg/installer/deployresources_resources.go
+++ b/pkg/installer/deployresources_resources.go
@@ -150,8 +150,7 @@ func (m *manager) computeBootstrapVM(installConfig *installconfig.InstallConfig)
 			},
 			DiagnosticsProfile: &mgmtcompute.DiagnosticsProfile{
 				BootDiagnostics: &mgmtcompute.BootDiagnostics{
-					Enabled:    to.BoolPtr(true),
-					StorageURI: to.StringPtr("https://cluster" + m.oc.Properties.StorageSuffix + ".blob." + m.env.Environment().StorageEndpointSuffix + "/"),
+					Enabled: to.BoolPtr(true),
 				},
 			},
 		},
@@ -222,8 +221,7 @@ func (m *manager) computeMasterVMs(installConfig *installconfig.InstallConfig, z
 			},
 			DiagnosticsProfile: &mgmtcompute.DiagnosticsProfile{
 				BootDiagnostics: &mgmtcompute.BootDiagnostics{
-					Enabled:    to.BoolPtr(true),
-					StorageURI: to.StringPtr("https://cluster" + m.oc.Properties.StorageSuffix + ".blob." + m.env.Environment().StorageEndpointSuffix + "/"),
+					Enabled: to.BoolPtr(true),
 				},
 			},
 		},


### PR DESCRIPTION
### Which issue this PR addresses:

Fixes [ARO-11606](https://issues.redhat.com/browse/ARO-11606)

### What this PR does / why we need it:

Updates our deployment for the bootstrap and control plane VMs to use [Azure Managed Boot Diagnostics](https://learn.microsoft.com/en-us/azure/virtual-machines/boot-diagnostics#enable-managed-boot-diagnostics), by removing the property for a custom storage account. This will cause these VMs to use an Azure-managed SA that is invisible to the cluster's subscription. 

### Test plan for issue:

- [X] Performed an ARO MIWI cluster install with this change successfully 
  - [X] Confirmed the ARO RP is still able to retrieve serial console logs for the cluster VMs
- [x] Performed an ARO CSP cluster install with this change successfully
  - [x] Confirmed the ARO RP is still able to retrieve serial console logs for the cluster VMs

### Is there any documentation that needs to be updated for this PR?

No

### How do you know this will function as expected in production? 

- The ARO-RP E2E [test](https://github.com/Azure/ARO-RP/blob/master/test/e2e/adminapi_serialconsole.go) for serial console log functionality will confirm that it is working after a new version of installer-aro-wrapper is deployed in a production region. 

/cherrypick release-4.15 release-4.14 release-4.13 release-4.12 