### PR TITLE
ARO-12466: Avoid terraform dependency in installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ endif
 ARO_IMAGE ?= $(ARO_IMAGE_BASE):$(VERSION)
 
 build-all:
-	go build -tags aro,containers_image_openpgp ./...
+	go build -tags altinfra,aro,containers_image_openpgp ./...
 
 aro: generate
-	go build -tags aro,containers_image_openpgp,codec.safe -ldflags "-X github.com/openshift/installer-aro-wrapper/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro
+	go build -tags altinfra,aro,containers_image_openpgp,codec.safe -ldflags "-X github.com/openshift/installer-aro-wrapper/pkg/util/version.GitCommit=$(VERSION)" ./cmd/aro
 
 clean:
 	rm -rf aro
@@ -66,7 +66,7 @@ validate-go-action:
 	@[ -z "$$(find -name "*:*")" ] || (echo error: filenames with colons are not allowed on Windows, please rename; exit 1)
 
 unit-test-go:
-	go run ./vendor/gotest.tools/gotestsum/main.go --format pkgname --junitfile report.xml -- -tags=aro,containers_image_openpgp -coverprofile=cover.out ./...
+	go run ./vendor/gotest.tools/gotestsum/main.go --format pkgname --junitfile report.xml -- -tags=altinfra,aro,containers_image_openpgp -coverprofile=cover.out ./...
 
 lint-go:
 	hack/lint-go.sh

--- a/pkg/installer/custominstallconfig.go
+++ b/pkg/installer/custominstallconfig.go
@@ -11,12 +11,16 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset"
+	"github.com/openshift/installer/pkg/asset/cluster"
 	"github.com/openshift/installer/pkg/asset/ignition"
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
+	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
+	"github.com/openshift/installer/pkg/asset/kubeconfig"
+	"github.com/openshift/installer/pkg/asset/password"
 	"github.com/openshift/installer/pkg/asset/releaseimage"
-	"github.com/openshift/installer/pkg/asset/targets"
 	"github.com/openshift/installer/pkg/asset/templates/content/bootkube"
+	"github.com/openshift/installer/pkg/asset/tls"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/yaml"
@@ -27,6 +31,18 @@ import (
 
 const (
 	cvoOverridesFilename = "manifests/cvo-overrides.yaml"
+)
+
+var (
+	targetAssets = []asset.WritableAsset{
+		&cluster.Metadata{},
+		&machine.MasterIgnitionCustomizations{},
+		&machine.WorkerIgnitionCustomizations{},
+		&cluster.TerraformVariables{},
+		&kubeconfig.AdminClient{},
+		&password.KubeadminPassword{},
+		&tls.JournalCertKey{},
+	}
 )
 
 // applyInstallConfigCustomisations modifies the InstallConfig and creates
@@ -87,7 +103,7 @@ func (m *manager) applyInstallConfigCustomisations(installConfig *installconfig.
 	g.Set(installConfig, image, clusterID, bootstrapLoggingConfig, dnsConfig, imageRegistryConfig, &boundSaSigningKey.BoundSASigningKey)
 
 	m.log.Print("resolving graph")
-	for _, a := range targets.Cluster {
+	for _, a := range targetAssets {
 		err = g.Resolve(a)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Compile with the altinfra tag, and use a local copy of the target list the same as the one in the installer-aro fork of the installer.

This ensures that when we switch to the upstream installer library, no terraform dependencies will be compiled in to the binary.