### PR TITLE
ARO-12457: Embed installer data in the binary

### DIFF
--- a/data.go
+++ b/data.go
@@ -1,0 +1,29 @@
+package data
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+
+	"github.com/openshift/installer/data"
+	//_ "github.com/openshift/installer/data/data"
+)
+
+//go:embed all:vendor/github.com/openshift/installer/data
+var installerData embed.FS
+
+func init() {
+	dataDir := "vendor/github.com/openshift/installer/data/data"
+	if _, err := installerData.ReadDir(dataDir); err != nil {
+		// openshift/installer-aro does not contain data in the filesystem, but
+		// instead has the generated data compiled in
+		return
+	}
+
+	dataFS, err := fs.Sub(installerData, dataDir)
+	if err != nil {
+		panic(err)
+	}
+	// Propagate our locally-generated data back into the installer library
+	data.Assets = http.FS(dataFS)
+}

--- a/hack/validate-imports/validate-imports.go
+++ b/hack/validate-imports/validate-imports.go
@@ -30,6 +30,8 @@ func validateUnderscoreImport(path string) error {
 	switch path {
 	case "net/http/pprof",
 		"github.com/openshift/installer-aro-wrapper/pkg/util/scheme",
+		"github.com/openshift/installer-aro-wrapper",
+		"github.com/openshift/installer/data/data",
 		"embed":
 		return nil
 	}

--- a/pkg/installer/data.go
+++ b/pkg/installer/data.go
@@ -1,0 +1,4 @@
+package installer
+
+// Import installer data
+import _ "github.com/openshift/installer-aro-wrapper"


### PR DESCRIPTION
Embed the installer's data/data directory in the binary and substitute it in the installer library where it is expected. This is to work around the fact that the upstream installer does not have the autogenerated data/assets_vfsdata.go file checked in to the repo, so it does not show up in the build.

Since the installer-aro fork _does_ have data/assets_vfsdata.go but does not export the data/data directory, embed the whole data directory and don't substitute it in if data/data does not exist.  So this should have no effect at the moment, but will do the right thing as soon as `github.com/openshift/installer/data/data` is imported from upstream.