### PR TITLE
ARO-12469: Added template manifest files to ignition

### DIFF
--- a/pkg/data/manifests/manifests_asset.go
+++ b/pkg/data/manifests/manifests_asset.go
@@ -1,0 +1,53 @@
+package manifests
+
+import (
+	"bytes"
+	"embed"
+	"fmt"
+
+	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
+	"github.com/openshift/installer/pkg/types"
+	"github.com/vincent-petithory/dataurl"
+
+	bootstrapfiles "github.com/openshift/installer-aro-wrapper/pkg/data/bootstrap"
+)
+
+//go:embed opt/*
+var assets embed.FS
+
+type ManifestsConfig struct {
+	AROWorkerRegistries string
+	HTTPSecret          string
+	AccountName         string
+	ContainerName       string
+	CloudName           string
+	AROIngressInternal  bool
+	AROIngressIP        string
+}
+
+func AppendManifestsFilesToBootstrap(bootstrap *bootstrap.Bootstrap, manifestsConfig ManifestsConfig) error {
+	err := bootstrapfiles.AddStorageFiles(bootstrap.Config, "opt", "opt", manifestsConfig, assets)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func AroWorkerRegistries(idss []types.ImageDigestSource) string {
+	b := &bytes.Buffer{}
+
+	fmt.Fprintf(b, "unqualified-search-registries = [\"registry.access.redhat.com\", \"docker.io\"]\n")
+
+	for _, ids := range idss {
+		fmt.Fprintf(b, "\n[[registry]]\n  prefix = \"\"\n  location = \"%s\"\n  mirror-by-digest-only = true\n", ids.Source)
+
+		for _, mirror := range ids.Mirrors {
+			fmt.Fprintf(b, "\n  [[registry.mirror]]\n    location = \"%s\"\n", mirror)
+		}
+	}
+
+	du := dataurl.New(b.Bytes(), "text/plain")
+	du.Encoding = dataurl.EncodingASCII
+
+	return du.String()
+}

--- a/pkg/data/manifests/opt/openshift/manifests/aro-imageregistry.yaml.template
+++ b/pkg/data/manifests/opt/openshift/manifests/aro-imageregistry.yaml.template
@@ -1,0 +1,16 @@
+apiVersion: imageregistry.operator.openshift.io/v1
+kind: Config
+metadata:
+  finalizers:
+  - imageregistry.operator.openshift.io/finalizer
+  name: cluster
+spec:
+  httpSecret: "{{ .HTTPSecret }}"
+  managementState: Managed
+  replicas: 2
+  storage:
+    azure:
+      accountName: "{{ .AccountName }}"
+      container: "{{ .ContainerName }}"
+      cloudName: "{{ .CloudName }}"
+    managementState: Unmanaged

--- a/pkg/data/manifests/opt/openshift/manifests/aro-ingress-namespace.yaml
+++ b/pkg/data/manifests/opt/openshift/manifests/aro-ingress-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-ingress

--- a/pkg/data/manifests/opt/openshift/manifests/aro-ingress-service.yaml.template
+++ b/pkg/data/manifests/opt/openshift/manifests/aro-ingress-service.yaml.template
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: router-default
+  namespace: openshift-ingress
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal: "{{ if .AROIngressInternal }}true{{ end }}"
+    service.beta.kubernetes.io/azure-load-balancer-ipv4: "{{ .AROIngressIP }}"
+  labels:
+    app: router
+    ingresscontroller.operator.openshift.io/owning-ingresscontroller: default
+spec:
+  externalTrafficPolicy: Local
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  selector:
+    ingresscontroller.operator.openshift.io/deployment-ingresscontroller: default
+  type: LoadBalancer

--- a/pkg/data/manifests/opt/openshift/manifests/aro-worker-registries.yaml.template
+++ b/pkg/data/manifests/opt/openshift/manifests/aro-worker-registries.yaml.template
@@ -1,0 +1,17 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 90-aro-worker-registries
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+      - contents:
+          source: "{{ .AROWorkerRegistries }}"
+        filesystem: root
+        mode: 420
+        path: /etc/containers/registries.conf

--- a/pkg/installer/custominstallconfig.go
+++ b/pkg/installer/custominstallconfig.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/openshift/installer-aro-wrapper/pkg/api"
 	"github.com/openshift/installer-aro-wrapper/pkg/cluster/graph"
+	"github.com/openshift/installer-aro-wrapper/pkg/data/manifests"
 	"github.com/openshift/installer-aro-wrapper/pkg/installer/dnsmasq"
 	"github.com/openshift/installer-aro-wrapper/pkg/installer/mdsd"
 )
@@ -144,6 +145,19 @@ func (m *manager) applyInstallConfigCustomisations(installConfig *installconfig.
 		return nil, err
 	}
 	err = mdsd.AppendMdsdFiles(bootstrapAsset, bootstrapLoggingConfig)
+	if err != nil {
+		return nil, err
+	}
+	config := manifests.ManifestsConfig{
+		AROWorkerRegistries: manifests.AroWorkerRegistries(installConfig.Config.ImageDigestSources),
+		HTTPSecret:          imageRegistryConfig.HTTPSecret,
+		AccountName:         imageRegistryConfig.AccountName,
+		ContainerName:       imageRegistryConfig.ContainerName,
+		CloudName:           installConfig.Config.Azure.CloudName.Name(),
+		AROIngressInternal:  installConfig.Config.Publish == "Internal",
+		AROIngressIP:        dnsConfig.IngressIP,
+	}
+	err = manifests.AppendManifestsFilesToBootstrap(bootstrapAsset, config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adding ARO template file manifests from the ARO fork to the wrapper
to generate them locally.