### PR TITLE
ARO-11341: Add extra files to manifest

### DIFF
--- a/pkg/installer/storage_files_testdata.go
+++ b/pkg/installer/storage_files_testdata.go
@@ -515,4 +515,36 @@ done < "${CONFIG_FILE}"
 cmp "${TEMP_FILE}" "${HOSTS_FILE}" || cp -f "${TEMP_FILE}" "${HOSTS_FILE}"
 # TEMP_FILE is not removed to avoid file create/delete and attributes copy churn
 `,
+	"/opt/openshift/manifests/cluster-dns-02-config.yml": `apiVersion: config.openshift.io/v1
+kind: DNS
+metadata:
+  creationTimestamp: null
+  name: cluster
+spec:
+  baseDomain: test-cluster.test.example.com
+  platform:
+    aws: null
+    type: ""
+status: {}
+`,
+	"/opt/openshift/openshift/99_openshift-cluster-api_master-user-data-secret.yaml": `apiVersion: v1
+kind: Secret
+metadata:
+  name: master-user-data
+  namespace: openshift-machine-api
+type: Opaque
+data:
+  disableTemplating: "dHJ1ZQo="
+  userData: test
+`,
+	"/opt/openshift/openshift/99_openshift-cluster-api_worker-user-data-secret.yaml": `apiVersion: v1
+kind: Secret
+metadata:
+  name: worker-user-data
+  namespace: openshift-machine-api
+type: Opaque
+data:
+  disableTemplating: "dHJ1ZQo="
+  userData: test
+`,
 }


### PR DESCRIPTION
Adding a few files into the manifest that were added in the ARO fork 
and missing here.

Adding master and user data secret and removing the DNS
config settings that the installer sets.

Commits referred:
https://github.com/openshift/installer-aro/commit/a6f7ca0485f399efb2e7a90d7e8d2aada288213d
https://github.com/hawkowl/ARO-Installer/commit/95a830f1cf0da2a0164dee7d46c9edc8d4676184