### PR TITLE
dnsmasq.conf: remove strict-order and add dns-forward-max

### DIFF
--- a/pkg/installer/dnsmasq/scripts/dnsmasq.conf.gotmpl
+++ b/pkg/installer/dnsmasq/scripts/dnsmasq.conf.gotmpl
@@ -1,6 +1,6 @@
 {{ define "dnsmasq.conf" }}
 resolv-file=/etc/resolv.conf.dnsmasq
-strict-order
+dns-forward-max=10000
 address=/api.{{ .ClusterDomain }}/{{ .APIIntIP }}
 address=/api-int.{{ .ClusterDomain }}/{{ .APIIntIP }}
 address=/.apps.{{ .ClusterDomain }}/{{ .IngressIP }}

--- a/pkg/installer/etchost/etchosts.go
+++ b/pkg/installer/etchost/etchosts.go
@@ -41,7 +41,7 @@ type etcHostsAROScriptTemplateData struct {
 }
 
 var aroConfTemplate = template.Must(template.New("etchosts").Parse(`{{ .APIIntIP }}	api.{{ .ClusterDomain }} api-int.{{ .ClusterDomain }}
-{{ $.GatewayPrivateEndpointIP }}	{{ range $GatewayDomain := .GatewayDomains }}{{ $GatewayDomain }} {{ end }}
+{{ $.GatewayPrivateEndpointIP }}	{{ range $i, $GatewayDomain := .GatewayDomains }}{{ if (gt $i 0) }} {{ end }}{{ $GatewayDomain }}{{ end }}
 `))
 
 var aroScriptTemplate = template.Must(template.New("etchostscript").Parse(`#!/bin/bash

--- a/pkg/installer/storage_files_testdata.go
+++ b/pkg/installer/storage_files_testdata.go
@@ -51,7 +51,7 @@ exit 0
 `,
 	"/etc/dnsmasq.conf": `
 resolv-file=/etc/resolv.conf.dnsmasq
-strict-order
+dns-forward-max=10000
 address=/api.test-cluster.test.example.com/203.0.113.1
 address=/api-int.test-cluster.test.example.com/203.0.113.1
 address=/.apps.test-cluster.test.example.com/192.0.2.1
@@ -79,7 +79,7 @@ cache-size=0
 	Port 24224
 `,
 	"/etc/hosts.d/aro.conf": `203.0.113.1	api.test-cluster.test.example.com api-int.test-cluster.test.example.com
-203.0.113.2	gateway.mock1.example.com gateway.mock2.example.com ` + `
+203.0.113.2	gateway.mock1.example.com gateway.mock2.example.com
 `,
 	"/etc/mdsd.d/mdsd.env": `MONITORING_GCS_ENVIRONMENT=test-logging-environment
 MONITORING_GCS_ACCOUNT=test-logging-account
@@ -175,7 +175,7 @@ spec:
     storage:
       files:
       - contents:
-          source: data:text/plain;charset=utf-8;base64,CnJlc29sdi1maWxlPS9ldGMvcmVzb2x2LmNvbmYuZG5zbWFzcQpzdHJpY3Qtb3JkZXIKYWRkcmVzcz0vYXBpLnRlc3QtY2x1c3Rlci50ZXN0LmV4YW1wbGUuY29tLzIwMy4wLjExMy4xCmFkZHJlc3M9L2FwaS1pbnQudGVzdC1jbHVzdGVyLnRlc3QuZXhhbXBsZS5jb20vMjAzLjAuMTEzLjEKYWRkcmVzcz0vLmFwcHMudGVzdC1jbHVzdGVyLnRlc3QuZXhhbXBsZS5jb20vMTkyLjAuMi4xCmFkZHJlc3M9L2dhdGV3YXkubW9jazEuZXhhbXBsZS5jb20vMjAzLjAuMTEzLjIKYWRkcmVzcz0vZ2F0ZXdheS5tb2NrMi5leGFtcGxlLmNvbS8yMDMuMC4xMTMuMgp1c2VyPWRuc21hc3EKZ3JvdXA9ZG5zbWFzcQpuby1ob3N0cwpjYWNoZS1zaXplPTAK
+          source: data:text/plain;charset=utf-8;base64,CnJlc29sdi1maWxlPS9ldGMvcmVzb2x2LmNvbmYuZG5zbWFzcQpkbnMtZm9yd2FyZC1tYXg9MTAwMDAKYWRkcmVzcz0vYXBpLnRlc3QtY2x1c3Rlci50ZXN0LmV4YW1wbGUuY29tLzIwMy4wLjExMy4xCmFkZHJlc3M9L2FwaS1pbnQudGVzdC1jbHVzdGVyLnRlc3QuZXhhbXBsZS5jb20vMjAzLjAuMTEzLjEKYWRkcmVzcz0vLmFwcHMudGVzdC1jbHVzdGVyLnRlc3QuZXhhbXBsZS5jb20vMTkyLjAuMi4xCmFkZHJlc3M9L2dhdGV3YXkubW9jazEuZXhhbXBsZS5jb20vMjAzLjAuMTEzLjIKYWRkcmVzcz0vZ2F0ZXdheS5tb2NrMi5leGFtcGxlLmNvbS8yMDMuMC4xMTMuMgp1c2VyPWRuc21hc3EKZ3JvdXA9ZG5zbWFzcQpuby1ob3N0cwpjYWNoZS1zaXplPTAK
           verification: {}
         group: {}
         mode: 420
@@ -261,7 +261,7 @@ spec:
     storage:
       files:
       - contents:
-          source: data:text/plain;charset=utf-8;base64,MjAzLjAuMTEzLjEJYXBpLnRlc3QtY2x1c3Rlci50ZXN0LmV4YW1wbGUuY29tIGFwaS1pbnQudGVzdC1jbHVzdGVyLnRlc3QuZXhhbXBsZS5jb20KMjAzLjAuMTEzLjIJZ2F0ZXdheS5tb2NrMS5leGFtcGxlLmNvbSBnYXRld2F5Lm1vY2syLmV4YW1wbGUuY29tIAo=
+          source: data:text/plain;charset=utf-8;base64,MjAzLjAuMTEzLjEJYXBpLnRlc3QtY2x1c3Rlci50ZXN0LmV4YW1wbGUuY29tIGFwaS1pbnQudGVzdC1jbHVzdGVyLnRlc3QuZXhhbXBsZS5jb20KMjAzLjAuMTEzLjIJZ2F0ZXdheS5tb2NrMS5leGFtcGxlLmNvbSBnYXRld2F5Lm1vY2syLmV4YW1wbGUuY29tCg==
         mode: 420
         overwrite: true
         path: /etc/hosts.d/aro.conf
@@ -318,7 +318,7 @@ spec:
     storage:
       files:
       - contents:
-          source: data:text/plain;charset=utf-8;base64,CnJlc29sdi1maWxlPS9ldGMvcmVzb2x2LmNvbmYuZG5zbWFzcQpzdHJpY3Qtb3JkZXIKYWRkcmVzcz0vYXBpLnRlc3QtY2x1c3Rlci50ZXN0LmV4YW1wbGUuY29tLzIwMy4wLjExMy4xCmFkZHJlc3M9L2FwaS1pbnQudGVzdC1jbHVzdGVyLnRlc3QuZXhhbXBsZS5jb20vMjAzLjAuMTEzLjEKYWRkcmVzcz0vLmFwcHMudGVzdC1jbHVzdGVyLnRlc3QuZXhhbXBsZS5jb20vMTkyLjAuMi4xCmFkZHJlc3M9L2dhdGV3YXkubW9jazEuZXhhbXBsZS5jb20vMjAzLjAuMTEzLjIKYWRkcmVzcz0vZ2F0ZXdheS5tb2NrMi5leGFtcGxlLmNvbS8yMDMuMC4xMTMuMgp1c2VyPWRuc21hc3EKZ3JvdXA9ZG5zbWFzcQpuby1ob3N0cwpjYWNoZS1zaXplPTAK
+          source: data:text/plain;charset=utf-8;base64,CnJlc29sdi1maWxlPS9ldGMvcmVzb2x2LmNvbmYuZG5zbWFzcQpkbnMtZm9yd2FyZC1tYXg9MTAwMDAKYWRkcmVzcz0vYXBpLnRlc3QtY2x1c3Rlci50ZXN0LmV4YW1wbGUuY29tLzIwMy4wLjExMy4xCmFkZHJlc3M9L2FwaS1pbnQudGVzdC1jbHVzdGVyLnRlc3QuZXhhbXBsZS5jb20vMjAzLjAuMTEzLjEKYWRkcmVzcz0vLmFwcHMudGVzdC1jbHVzdGVyLnRlc3QuZXhhbXBsZS5jb20vMTkyLjAuMi4xCmFkZHJlc3M9L2dhdGV3YXkubW9jazEuZXhhbXBsZS5jb20vMjAzLjAuMTEzLjIKYWRkcmVzcz0vZ2F0ZXdheS5tb2NrMi5leGFtcGxlLmNvbS8yMDMuMC4xMTMuMgp1c2VyPWRuc21hc3EKZ3JvdXA9ZG5zbWFzcQpuby1ob3N0cwpjYWNoZS1zaXplPTAK
           verification: {}
         group: {}
         mode: 420
@@ -381,7 +381,7 @@ spec:
     storage:
       files:
       - contents:
-          source: data:text/plain;charset=utf-8;base64,MjAzLjAuMTEzLjEJYXBpLnRlc3QtY2x1c3Rlci50ZXN0LmV4YW1wbGUuY29tIGFwaS1pbnQudGVzdC1jbHVzdGVyLnRlc3QuZXhhbXBsZS5jb20KMjAzLjAuMTEzLjIJZ2F0ZXdheS5tb2NrMS5leGFtcGxlLmNvbSBnYXRld2F5Lm1vY2syLmV4YW1wbGUuY29tIAo=
+          source: data:text/plain;charset=utf-8;base64,MjAzLjAuMTEzLjEJYXBpLnRlc3QtY2x1c3Rlci50ZXN0LmV4YW1wbGUuY29tIGFwaS1pbnQudGVzdC1jbHVzdGVyLnRlc3QuZXhhbXBsZS5jb20KMjAzLjAuMTEzLjIJZ2F0ZXdheS5tb2NrMS5leGFtcGxlLmNvbSBnYXRld2F5Lm1vY2syLmV4YW1wbGUuY29tCg==
         mode: 420
         overwrite: true
         path: /etc/hosts.d/aro.conf


### PR DESCRIPTION
### Which issue this PR addresses:

<!--
Please include a link to the ADO work item as well as any GitHub issues.

Usage: `Fixes #<GitHub issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes [ARO-2799](https://issues.redhat.com//browse/ARO-2799) and [ARO-15424](https://issues.redhat.com//browse/ARO-15424)

Companion PR to https://github.com/Azure/ARO-RP/pull/4135

### What this PR does / why we need it:

Implementation of ADR: https://docs.google.com/document/d/1nA1udF8RbJdpFgW3sezlEQGPMgqEQAZ7zvbCu18Zr5Q/

I also slipped in a small tweak to the etchosts template since my editor kept wanting to delete the trailing space from storage_files_testdata.go