### PR TITLE
[4.16] Reduce duplication of manifest generation and remove unneccessary manifests

### DIFF
--- a/cmd/aro/create.go
+++ b/cmd/aro/create.go
@@ -54,6 +54,7 @@ var (
 
 				runner := func(directory string, manifests []asset.WritableAsset) error {
 					for _, m := range manifests {
+						logrus.Infof("resolving asset %s from graph", m.Name())
 						err = g.Resolve(m)
 						if err != nil {
 							err = errors.Wrapf(err, "failed to fetch %s", m.Name())
@@ -70,12 +71,6 @@ var (
 						}
 					}
 					return nil
-				}
-
-				err = runner(rootOpts.dir, targetassets.Manifests)
-				if err != nil {
-					logrus.Error(err)
-					logrus.Exit(1)
 				}
 
 				err = runner(rootOpts.dir, targetassets.IgnitionConfigs)

--- a/pkg/installer/custominstallconfig.go
+++ b/pkg/installer/custominstallconfig.go
@@ -23,7 +23,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/releaseimage"
-	"github.com/openshift/installer/pkg/asset/targets"
+	targetassets "github.com/openshift/installer/pkg/asset/targets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -118,7 +118,7 @@ func (m *manager) applyInstallConfigCustomisations(installConfig *installconfig.
 	g.Set(installConfig, image, clusterID, &boundSaSigningKey.BoundSASigningKey)
 
 	m.log.Print("resolving graph")
-	for _, a := range targets.IgnitionConfigs {
+	for _, a := range targetassets.IgnitionConfigs {
 		err = g.Resolve(a)
 		if err != nil {
 			return nil, err

--- a/pkg/installer/custominstallconfig.go
+++ b/pkg/installer/custominstallconfig.go
@@ -18,16 +18,12 @@ import (
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/installer/pkg/asset"
-	"github.com/openshift/installer/pkg/asset/cluster"
-	"github.com/openshift/installer/pkg/asset/cluster/tfvars"
 	"github.com/openshift/installer/pkg/asset/ignition"
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
-	"github.com/openshift/installer/pkg/asset/kubeconfig"
-	"github.com/openshift/installer/pkg/asset/password"
 	"github.com/openshift/installer/pkg/asset/releaseimage"
-	"github.com/openshift/installer/pkg/asset/tls"
+	"github.com/openshift/installer/pkg/asset/targets"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -47,16 +43,6 @@ const (
 )
 
 var (
-	targetAssets = []asset.WritableAsset{
-		&cluster.Metadata{},
-		&machine.MasterIgnitionCustomizations{},
-		&machine.WorkerIgnitionCustomizations{},
-		&tfvars.TerraformVariables{},
-		&kubeconfig.AdminClient{},
-		&password.KubeadminPassword{},
-		&tls.JournalCertKey{},
-		&tls.RootCA{},
-	}
 	userDataTmpl = template.Must(template.New("user-data").Parse(`apiVersion: v1
 kind: Secret
 metadata:
@@ -132,7 +118,7 @@ func (m *manager) applyInstallConfigCustomisations(installConfig *installconfig.
 	g.Set(installConfig, image, clusterID, &boundSaSigningKey.BoundSASigningKey)
 
 	m.log.Print("resolving graph")
-	for _, a := range targetAssets {
+	for _, a := range targets.IgnitionConfigs {
 		err = g.Resolve(a)
 		if err != nil {
 			return nil, err

--- a/pkg/installer/custominstallconfig_test.go
+++ b/pkg/installer/custominstallconfig_test.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/2018-03-01/resources/mgmt/resources"
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
@@ -300,13 +299,6 @@ func mockClientCalls(client *mock.MockAPI) {
 			Location: to.StringPtr("centralus"),
 		}, nil).
 		AnyTimes()
-	client.EXPECT().GetGroup(gomock.Any(), "test-resource-group").
-		Return(&resources.Group{
-			ID:       to.StringPtr("test-resource-group"),
-			Location: to.StringPtr("centralus"),
-		}, nil)
-	client.EXPECT().GetHyperVGenerationVersion(gomock.Any(), "Standard_D2s_v3", "centralus", "").
-		Return("V2", nil)
 }
 
 func TestApplyInstallConfigCustomisations(t *testing.T) {

--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -238,6 +238,12 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 						CloudName:                azuretypes.CloudEnvironment(m.env.Environment().Name),
 						OutboundType:             outboundType,
 						ResourceGroupName:        resourceGroup,
+						// We specify BaseDomainResourceGroupName even though we
+						// do not create Public DNS zones to pass validation.
+						// See https://issues.redhat.com/browse/OCPSTRAT-991 for
+						// a more permanent fix (disabling public DNS
+						// provisioning).
+						BaseDomainResourceGroupName: resourceGroup,
 					},
 				},
 				PullSecret: pullSecret,


### PR DESCRIPTION
This change reduces the number of manifests that the wrapper generates, as we only care about the ignition ones.

This also has the change to remove a conditional in the Installer.