### PR TITLE
ARO: Added base domain value to bypass check

### DIFF
--- a/pkg/installer/custominstallconfig.go
+++ b/pkg/installer/custominstallconfig.go
@@ -62,6 +62,11 @@ func (m *manager) applyInstallConfigCustomisations(installConfig *installconfig.
 		InfraID: m.oc.Properties.InfraID,
 	}
 
+	// Adding a bogus base domain to bypass installer check for base domain.
+	// ARO does not use the base domain to create DNS entries but the installer
+	// does so adding this random base domain value.
+	installConfig.Config.Azure.BaseDomainResourceGroupName = installConfig.Config.Azure.ResourceGroupName
+
 	bootstrapLoggingConfig, err := m.getBootstrapLoggingConfig(m.env, m.oc)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Adding a base domain value to the install config to bypass installer check for a value. ARO does not use the base domain for the DNS entry creation so nothing changes as far as ARO is concerned.

[1] will remove the skip check validation for ARO so adding a base domain here to make it work

[1] - https://github.com/openshift/installer/pull/9144