### PR TITLE
Create `/output/manifests` directory for Hive install manager

### DIFF
--- a/pkg/installer/custominstallconfig.go
+++ b/pkg/installer/custominstallconfig.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"path/filepath"
 	"text/template"
 
@@ -42,6 +43,7 @@ import (
 )
 
 const (
+	outputManifestDir    = "/output/manifests"
 	cvoOverridesFilename = "manifests/cvo-overrides.yaml"
 )
 
@@ -204,6 +206,13 @@ func (m *manager) applyInstallConfigCustomisations(installConfig *installconfig.
 }
 
 func appendFilesToBootstrap(a asset.WritableAsset, g graph.Graph) error {
+	// Hack: Since https://github.com/openshift/installer-aro-wrapper/commit/d7faee68ae29682f82938ea42dbdc641fa150c28#diff-f63cf295ca563cf25cc0b5abf73b229858b2a389b4afa5bd9a82e05cfda47836
+	// removed the creation of this directory, we need to create it here; the Hive install
+	// manager depends on it and assumes that it exists.
+	if err := os.MkdirAll(outputManifestDir, 0755); err != nil {
+		return errors.Wrapf(err, "failed to create directory %s", outputManifestDir)
+	}
+
 	bootstrap := g.Get(&bootstrap.Bootstrap{}).(*bootstrap.Bootstrap)
 	for _, file := range a.Files() {
 		manifest := ignition.FileFromBytes(filepath.Join(rootPath, file.Filename), "root", 0644, file.Data)


### PR DESCRIPTION
Context explained in code comment. Will fix 4.16 and 4.17 MIWI installs.

I validated the changes by testing 4.16 and 4.17 MIWI + CSP installs in local dev.