### PR TITLE
[ARO-17219, 4.16] Support 4 AZs

### DIFF
--- a/pkg/installer/deployresources.go
+++ b/pkg/installer/deployresources.go
@@ -57,12 +57,19 @@ func (m *manager) deployResourceTemplate(ctx context.Context) error {
 		}
 	}
 
+	params["controlPlaneZones"] = map[string]interface{}{
+		"value": installConfig.Config.ControlPlane.Platform.Azure.Zones,
+	}
+
 	t := &arm.Template{
 		Schema:         "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
 		ContentVersion: "1.0.0.0",
 		Parameters: map[string]*arm.TemplateParameter{
 			"sas": {
 				Type: paramType,
+			},
+			"controlPlaneZones": {
+				Type: "array",
 			},
 		},
 		Resources: []*arm.Resource{
@@ -84,6 +91,6 @@ func zones(installConfig *installconfig.InstallConfig) *[]string {
 		return nil
 	} else {
 		// Use the zones we have been specified
-		return &installConfig.Config.ControlPlane.Platform.Azure.Zones
+		return &[]string{"[parameters('controlPlaneZones')[copyIndex(0)]]"}
 	}
 }

--- a/pkg/installer/deployresources_test.go
+++ b/pkg/installer/deployresources_test.go
@@ -28,7 +28,7 @@ func TestZones(t *testing.T) {
 		{
 			name:       "zonal",
 			zones:      []string{"1", "2", "3"},
-			wantMaster: &[]string{"1", "2", "3"},
+			wantMaster: &[]string{"[parameters('controlPlaneZones')[copyIndex(0)]]"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/installer/deployresources_test.go
+++ b/pkg/installer/deployresources_test.go
@@ -18,53 +18,21 @@ func TestZones(t *testing.T) {
 		name       string
 		zones      []string
 		region     string
-		replicas   int64
 		wantMaster *[]string
-		wantErr    string
 	}{
 		{
-			name:       "no zones, 3 replicas",
+			name:       "non-zonal",
 			zones:      []string{""},
 			wantMaster: nil,
 		},
 		{
-			name:  "1 zone, 3 replicas",
-			zones: []string{"1"},
-			wantMaster: &[]string{
-				"1",
-			},
-		},
-		{
-			name:  "2 zones, 3 replicas",
-			zones: []string{"1", "2"},
-			wantMaster: &[]string{
-				"1",
-				"2",
-			},
-		},
-		{
-			name:       "3 zones, 3 replicas",
+			name:       "zonal",
 			zones:      []string{"1", "2", "3"},
-			wantMaster: &[]string{"[string(copyIndex(1))]"},
-		},
-		{
-			name:    "4 zones, 3 replicas",
-			zones:   []string{"1", "2", "3", "4"},
-			wantErr: "cluster creation with 4 zone(s) and 3 replica(s) is unsupported",
-		},
-		{
-			name:     "4 zones, 4 replicas",
-			zones:    []string{"1", "2", "3", "4"},
-			replicas: 4,
-			wantErr:  "cluster creation with 4 zone(s) and 4 replica(s) is unsupported",
+			wantMaster: &[]string{"1", "2", "3"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.replicas != 4 {
-				tt.replicas = 3
-			}
-
-			zones, err := zones(&installconfig.InstallConfig{
+			z := zones(&installconfig.InstallConfig{
 				AssetBase: installconfig.AssetBase{
 					Config: &types.InstallConfig{
 						ControlPlane: &types.MachinePool{
@@ -73,7 +41,7 @@ func TestZones(t *testing.T) {
 									Zones: tt.zones,
 								},
 							},
-							Replicas: to.Int64Ptr(tt.replicas),
+							Replicas: to.Int64Ptr(3),
 						},
 						Platform: types.Platform{
 							Azure: &azuretypes.Platform{
@@ -86,12 +54,8 @@ func TestZones(t *testing.T) {
 					},
 				},
 			})
-			if err != nil && tt.wantErr != err.Error() ||
-				err == nil && tt.wantErr != "" {
-				t.Error(err)
-			}
-			if !reflect.DeepEqual(tt.wantMaster, zones) {
-				t.Errorf("Expected master %v, got master %v", tt.wantMaster, zones)
+			if !reflect.DeepEqual(tt.wantMaster, z) {
+				t.Errorf("Expected master %v, got master %v", tt.wantMaster, z)
 			}
 		})
 	}

--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
@@ -33,6 +34,8 @@ import (
 	"github.com/openshift/installer-aro-wrapper/pkg/util/stringutils"
 	"github.com/openshift/installer-aro-wrapper/pkg/util/subnet"
 )
+
+const CONTROL_PLANE_MACHINE_COUNT = 3
 
 func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.InstallConfig, *releaseimage.Image, error) {
 	resourceGroup := stringutils.LastTokenByte(m.oc.Properties.ClusterProfile.ResourceGroupID, '/')
@@ -88,22 +91,20 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
-	masterZones := computeskus.Zones(masterSKU)
-	if len(masterZones) == 0 {
-		masterZones = []string{""}
-	}
+
 	masterVMNetworkingType := determineVMNetworkingType(masterSKU)
 
 	workerSKU, err := m.env.VMSku(string(m.oc.Properties.WorkerProfiles[0].VMSize))
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
-	workerZones := computeskus.Zones(workerSKU)
-	if len(workerZones) == 0 {
-		workerZones = []string{""}
-	}
+
 	workerVMNetworkingType := determineVMNetworkingType(workerSKU)
 
+	controlPlaneZones, workerZones, err := determineAvailabilityZones(masterSKU, workerSKU)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
 
 	// Set NetworkType to OVNKubernetes by default
 	softwareDefinedNetwork := string(api.SoftwareDefinedNetworkOVNKubernetes)
@@ -185,10 +186,10 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 				},
 				ControlPlane: &types.MachinePool{
 					Name:     "master",
-					Replicas: to.Int64Ptr(3),
+					Replicas: to.Int64Ptr(CONTROL_PLANE_MACHINE_COUNT),
 					Platform: types.MachinePoolPlatform{
 						Azure: &azuretypes.MachinePool{
-							Zones:            masterZones,
+							Zones:            controlPlaneZones,
 							InstanceType:     string(m.oc.Properties.MasterProfile.VMSize),
 							EncryptionAtHost: m.oc.Properties.MasterProfile.EncryptionAtHost == api.EncryptionAtHostEnabled,
 							VMNetworkingType: masterVMNetworkingType,
@@ -367,4 +368,40 @@ func (m *manager) newInstallConfigClientCertificateCredential(tenantId, subscrip
 		ClientID:              m.env.FPClientID(),
 		ClientCertificatePath: clientCertificateFile.Name(),
 	}, nil
+}
+
+func determineAvailabilityZones(controlPlaneSKU, workerSKU *mgmtcompute.ResourceSku) ([]string, []string, error) {
+	// We handle the case where regions have no zones or >= zones than replicas,
+	// but not when replicas > zones. We (currently) only support 3 control
+	// plane replicas and Azure AZs will always be a minimum of 3, see
+	// https://azure.microsoft.com/en-us/blog/our-commitment-to-expand-azure-availability-zones-to-more-regions/
+	controlPlaneZones := computeskus.Zones(controlPlaneSKU)
+	if len(controlPlaneZones) == 0 {
+		controlPlaneZones = []string{""}
+	} else if len(controlPlaneZones) < CONTROL_PLANE_MACHINE_COUNT {
+		return nil, nil, fmt.Errorf("cluster creation with %d zones and %d control plane replicas is unsupported", len(controlPlaneZones), CONTROL_PLANE_MACHINE_COUNT)
+	} else if len(controlPlaneZones) >= CONTROL_PLANE_MACHINE_COUNT {
+		// Some regions may have more availability zones than control plane
+		// replicas. In that case, sort them (just in case) and pick the first
+		// ones in the list to satisfy the replica requirements. We may want to
+		// be smarter in future, since if we have 3 replicas we will never take
+		// advantage of a 4th zone if all 4 have SKU availability, but this will
+		// cover the case where a SKU is available in zones 1, 2, 4 correctly.
+		slices.Sort(controlPlaneZones)
+		controlPlaneZones = controlPlaneZones[:CONTROL_PLANE_MACHINE_COUNT]
+	}
+
+	// Unlike above, we don't particularly mind if we pass the Installer more
+	// zones than the usual 3 in a zonal region, since it automatically balances
+	// them across the available zones. However, if a SKU is available in less
+	// than 3 regions we will fail, since taints on cluster components like
+	// Prometheus will prevent the eventual install from turning healthy.
+	workerZones := computeskus.Zones(workerSKU)
+	if len(workerZones) == 0 {
+		workerZones = []string{""}
+	} else if len(workerZones) < 3 {
+		return nil, nil, fmt.Errorf("cluster creation with a worker SKU available on less than 3 zones is unsupported (available: %d)", len(workerZones))
+	}
+
+	return controlPlaneZones, workerZones, nil
 }

--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -104,11 +104,6 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 	}
 	workerVMNetworkingType := determineVMNetworkingType(workerSKU)
 
-	// Standard_D8s_v3 is only available in one zone in centraluseuap, so we need a non-zonal install in that region
-	if strings.EqualFold(m.oc.Location, "centraluseuap") {
-		workerZones = []string{""}
-		masterZones = []string{""}
-	}
 
 	// Set NetworkType to OVNKubernetes by default
 	softwareDefinedNetwork := string(api.SoftwareDefinedNetworkOVNKubernetes)

--- a/pkg/installer/generateconfig_test.go
+++ b/pkg/installer/generateconfig_test.go
@@ -4,10 +4,12 @@ package installer
 // Licensed under the Apache License 2.0.
 
 import (
+	"reflect"
 	"testing"
 
 	mgmtcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/google/go-cmp/cmp"
 	"github.com/openshift/installer/pkg/types/azure"
 )
 
@@ -41,6 +43,92 @@ func TestVMNetworkingType(t *testing.T) {
 
 			if result != tt.wantType {
 				t.Error(result)
+			}
+		})
+	}
+}
+
+func TestDetermineZones(t *testing.T) {
+	for _, tt := range []struct {
+		name                  string
+		controlPlaneSkuZones  []string
+		workerSkuZones        []string
+		wantControlPlaneZones []string
+		wantWorkerZones       []string
+		wantErr               string
+	}{
+
+		{
+			name:                  "non-zonal control plane, zonal workers",
+			controlPlaneSkuZones:  nil,
+			workerSkuZones:        []string{"1", "2", "3"},
+			wantControlPlaneZones: []string{""},
+			wantWorkerZones:       []string{"1", "2", "3"},
+		},
+		{
+			name:                  "zonal control plane, non-zonal workers",
+			controlPlaneSkuZones:  []string{"1", "2", "3"},
+			workerSkuZones:        nil,
+			wantControlPlaneZones: []string{"1", "2", "3"},
+			wantWorkerZones:       []string{""},
+		},
+		{
+			name:                  "zonal control plane, zonal workers",
+			controlPlaneSkuZones:  []string{"1", "2", "3"},
+			workerSkuZones:        []string{"1", "2", "3"},
+			wantControlPlaneZones: []string{"1", "2", "3"},
+			wantWorkerZones:       []string{"1", "2", "3"},
+		},
+		{
+			name:                  "region with 4 availability zones, control plane uses first 3, workers use all",
+			controlPlaneSkuZones:  []string{"1", "2", "3", "4"},
+			workerSkuZones:        []string{"1", "2", "3", "4"},
+			wantControlPlaneZones: []string{"1", "2", "3"},
+			wantWorkerZones:       []string{"1", "2", "3", "4"},
+		},
+		{
+			name:                 "not enough control plane zones",
+			controlPlaneSkuZones: []string{"1", "2"},
+			workerSkuZones:       []string{"1", "2", "3"},
+			wantErr:              "cluster creation with 2 zones and 3 control plane replicas is unsupported",
+		},
+		{
+			name:                 "not enough worker zones",
+			controlPlaneSkuZones: []string{"1", "2", "3"},
+			workerSkuZones:       []string{"1", "2"},
+			wantErr:              "cluster creation with a worker SKU available on less than 3 zones is unsupported (available: 2)",
+		},
+		{
+			name:                  "region with 4 availability zones, control plane only available in non-consecutive 3, workers use all",
+			controlPlaneSkuZones:  []string{"1", "2", "4"},
+			workerSkuZones:        []string{"1", "2", "3", "4"},
+			wantControlPlaneZones: []string{"1", "2", "4"},
+			wantWorkerZones:       []string{"1", "2", "3", "4"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			controlPlaneSku := &mgmtcompute.ResourceSku{
+				LocationInfo: &[]mgmtcompute.ResourceSkuLocationInfo{
+					{Zones: &tt.controlPlaneSkuZones},
+				},
+			}
+			workerSku := &mgmtcompute.ResourceSku{
+				LocationInfo: &[]mgmtcompute.ResourceSkuLocationInfo{
+					{Zones: &tt.workerSkuZones},
+				},
+			}
+
+			controlPlaneZones, workerZones, err := determineAvailabilityZones(controlPlaneSku, workerSku)
+			if err != nil && err.Error() != tt.wantErr {
+				t.Error(cmp.Diff(err, tt.wantErr))
+			}
+
+			if !reflect.DeepEqual(controlPlaneZones, tt.wantControlPlaneZones) {
+				t.Error(cmp.Diff(controlPlaneZones, tt.wantControlPlaneZones))
+			}
+
+			if !reflect.DeepEqual(workerZones, tt.wantWorkerZones) {
+				t.Error(cmp.Diff(workerZones, tt.wantWorkerZones))
 			}
 		})
 	}


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-17219

This supports 4 AZs in a general no-op to how we do it right now, as well as potentially squashing some install failure bugs that might be due to picking SKUs available in only 2 AZs for workers and preventing things with taints from installing, maybe.