### PR TITLE
Add red-hat-managed: true tag to install-config

### DIFF
--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -252,6 +252,9 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 						// a more permanent fix (disabling public DNS
 						// provisioning).
 						BaseDomainResourceGroupName: resourceGroup,
+						UserTags: map[string]string{
+							"red-hat-managed": "true",
+						},
 					},
 				},
 				PullSecret: pullSecret,


### PR DESCRIPTION
https://issues.redhat.com/browse/ARO-21174

Adds red-hat-managed: true tag to the install config for new clusters. This will propagate to the on-cluster infrastructure CR, which will then be used by OpenShift to add this tag to all Azure resources that are part of the cluster.

Tested against a 4.16 install