### PR TITLE
Revert "Add red-hat-managed: true tag to install-config"

### DIFF
--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -252,9 +252,6 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 						// a more permanent fix (disabling public DNS
 						// provisioning).
 						BaseDomainResourceGroupName: resourceGroup,
-						UserTags: map[string]string{
-							"red-hat-managed": "true",
-						},
 					},
 				},
 				PullSecret: pullSecret,


### PR DESCRIPTION
This reverts commit 326633f196fe06cd59beb16bf77070459e4d0ada due to an issue identified in public cloud.