### PR TITLE
[release-4.19] Revert "Add red-hat-managed: true tag to install-config"

### DIFF
--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -266,9 +266,6 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 								Type: v1beta1.VMIdentityNone,
 							},
 						},
-						UserTags: map[string]string{
-							"red-hat-managed": "true",
-						},
 					},
 				},
 				PullSecret: pullSecret,


### PR DESCRIPTION
This reverts commit 326633f196fe06cd59beb16bf77070459e4d0ada.