### PR TITLE
Make builder and base images configurable via build args

### DIFF
--- a/Dockerfile.aro
+++ b/Dockerfile.aro
@@ -1,8 +1,12 @@
 # Uses a multi-stage container build to build installer-aro-wrapper.
 #
 ARG REGISTRY=registry.access.redhat.com
-ARG BUILDER_REGISTRY=registry.ci.openshift.org/ocp/builder
-FROM ${BUILDER_REGISTRY}:rhel-9-golang-1.24-openshift-4.20 AS builder
+ARG REPOSITORY=ubi9/ubi-minimal
+ARG TAG=latest
+ARG BUILDER_REGISTRY=registry.ci.openshift.org
+ARG BUILDER_REPOSITORY=ocp/builder
+ARG BUILDER_TAG=rhel-9-golang-1.24-openshift-4.20
+FROM ${BUILDER_REGISTRY}/${BUILDER_REPOSITORY}:${BUILDER_TAG} AS builder
 
 ENV GO_COMPLIANCE_INFO=0
 USER root
@@ -16,7 +20,7 @@ COPY . /app
 RUN git config --system --add safe.directory '*'
 RUN make aro RELEASE=${IS_OFFICIAL_RELEASE} -o generate && make validate-fips
 
-FROM ${REGISTRY}/ubi9/ubi-minimal
+FROM ${REGISTRY}/${REPOSITORY}:${TAG}
 RUN microdnf update -y && microdnf clean all -y
 COPY --from=builder /app/aro /bin/openshift-install
 ENTRYPOINT ["/bin/openshift-install"]


### PR DESCRIPTION
Added `BUILDER_IMAGE` and `BASE_IMAGE` build args to allow customizing the container images used for building and runtime without modifying the Dockerfile.

This makes the build more flexible for different environments (e.g., using MCR images for OneBranch pipelines).

**Changes:**
- Added `BUILDER_IMAGE` build arg (default: `rhel-9-golang-1.24-openshift-4.20`)
- Added `BASE_IMAGE` build arg (default: `ubi9/ubi-minimal`)
- Defaults maintain existing behavior

**Usage example with MCR images:**
docker build \
  --build-arg REGISTRY=mcr.microsoft.com \
  --build-arg BUILDER_REGISTRY=mcr.microsoft.com/onebranch/azurelinux/build \
  --build-arg BUILDER_IMAGE=3.0 \
  --build-arg BASE_IMAGE=azurelinux/base/core:3.0 \
  -t aro-installer:latest .Related: Azure/sdp-pipelines PR for OneBranch pipeline integration.