### PR TITLE
Auto-select Gen2 images for Azure VMs requiring them

### DIFF
--- a/pkg/installer/generateconfig_test.go
+++ b/pkg/installer/generateconfig_test.go
@@ -50,6 +50,87 @@ func TestVMNetworkingType(t *testing.T) {
 	}
 }
 
+func TestDetermineHyperVGeneration(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		sku            *mgmtcompute.ResourceSku
+		wantGeneration string
+		wantErr        string
+	}{
+		{
+			name: "sku supports both V1 and V2, should prefer V2",
+			sku: &mgmtcompute.ResourceSku{
+				Name: to.StringPtr("Standard_D8s_v3"),
+				Capabilities: &[]mgmtcompute.ResourceSkuCapabilities{
+					{Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")},
+				},
+			},
+			wantGeneration: "V2",
+		},
+		{
+			name: "sku supports only V2",
+			sku: &mgmtcompute.ResourceSku{
+				Name: to.StringPtr("Standard_D8s_v6"),
+				Capabilities: &[]mgmtcompute.ResourceSkuCapabilities{
+					{Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V2")},
+				},
+			},
+			wantGeneration: "V2",
+		},
+		{
+			name: "sku supports only V1, should fallback to V1",
+			sku: &mgmtcompute.ResourceSku{
+				Name: to.StringPtr("Standard_D2_v2"),
+				Capabilities: &[]mgmtcompute.ResourceSkuCapabilities{
+					{Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1")},
+				},
+			},
+			wantGeneration: "V1",
+		},
+		{
+			name: "sku with empty capabilities returns error",
+			sku: &mgmtcompute.ResourceSku{
+				Name:         to.StringPtr("Standard_Empty"),
+				Capabilities: &[]mgmtcompute.ResourceSkuCapabilities{},
+			},
+			wantErr: "no capabilities found for SKU Standard_Empty",
+		},
+		{
+			name: "sku missing HyperVGenerations capability returns error",
+			sku: &mgmtcompute.ResourceSku{
+				Name: to.StringPtr("Standard_NoHyperV"),
+				Capabilities: &[]mgmtcompute.ResourceSkuCapabilities{
+					{Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")},
+					{Name: to.StringPtr("vCPUs"), Value: to.StringPtr("8")},
+				},
+			},
+			wantErr: "could not fetch HyperV generation for SKU Standard_NoHyperV: unable to determine HyperVGeneration version",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			generation, err := determineHyperVGeneration(tt.sku)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Errorf("expected error %q, got nil", tt.wantErr)
+				} else if err.Error() != tt.wantErr {
+					t.Errorf("expected error %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if generation != tt.wantGeneration {
+				t.Errorf("expected generation %q, got %q", tt.wantGeneration, generation)
+			}
+		})
+	}
+}
+
 func TestDetermineZones(t *testing.T) {
 	for _, tt := range []struct {
 		name                  string

--- a/pkg/util/computeskus/computeskus.go
+++ b/pkg/util/computeskus/computeskus.go
@@ -48,6 +48,20 @@ func IsRestricted(skus map[string]*mgmtcompute.ResourceSku, location, VMSize str
 	return false
 }
 
+// GetCapabilityMap converts *[]ResourceSkuCapabilities to map[string]string
+func GetCapabilityMap(sku *mgmtcompute.ResourceSku) (map[string]string, bool) {
+	if sku.Capabilities == nil || len(*sku.Capabilities) == 0 {
+		return nil, false
+	}
+	capabilityMap := make(map[string]string, len(*sku.Capabilities))
+	for _, c := range *sku.Capabilities {
+		if c.Name != nil && c.Value != nil {
+			capabilityMap[*c.Name] = *c.Value
+		}
+	}
+	return capabilityMap, len(capabilityMap) > 0
+}
+
 // FilterVMSizes filters resource SKU by location and returns only virtual machines, their names, restrictions, location info, and capabilities.
 func FilterVMSizes(skus []mgmtcompute.ResourceSku, location string) map[string]*mgmtcompute.ResourceSku {
 	vmskus := map[string]*mgmtcompute.ResourceSku{}

--- a/pkg/util/computeskus/computeskus_test.go
+++ b/pkg/util/computeskus/computeskus_test.go
@@ -255,3 +255,54 @@ func TestIsRestricted(t *testing.T) {
 		})
 	}
 }
+
+func TestGetCapabilityMap(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		sku        *mgmtcompute.ResourceSku
+		wantMap    map[string]string
+		wantResult bool
+	}{
+		{
+			name: "sku with multiple capabilities",
+			sku: &mgmtcompute.ResourceSku{
+				Capabilities: &[]mgmtcompute.ResourceSkuCapabilities{
+					{Name: to.StringPtr("HyperVGenerations"), Value: to.StringPtr("V1,V2")},
+					{Name: to.StringPtr("AcceleratedNetworkingEnabled"), Value: to.StringPtr("True")},
+					{Name: to.StringPtr("vCPUs"), Value: to.StringPtr("8")},
+				},
+			},
+			wantMap: map[string]string{
+				"HyperVGenerations":            "V1,V2",
+				"AcceleratedNetworkingEnabled": "True",
+				"vCPUs":                        "8",
+			},
+			wantResult: true,
+		},
+		{
+			name:       "sku with nil capabilities",
+			sku:        &mgmtcompute.ResourceSku{},
+			wantMap:    nil,
+			wantResult: false,
+		},
+		{
+			name: "sku with empty capabilities slice",
+			sku: &mgmtcompute.ResourceSku{
+				Capabilities: &[]mgmtcompute.ResourceSkuCapabilities{},
+			},
+			wantMap:    nil,
+			wantResult: false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resultMap, result := GetCapabilityMap(tt.sku)
+
+			if !reflect.DeepEqual(resultMap, tt.wantMap) {
+				t.Errorf("map mismatch: %s", cmp.Diff(tt.wantMap, resultMap))
+			}
+			if result != tt.wantResult {
+				t.Errorf("expected result %v, got %v", tt.wantResult, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Automatically detect when Azure VM sizes support Generation 2 hypervisor (e.g., Standard_D8s_v6) and select the appropriate Gen2 image SKU ("419-v2") instead of Gen1 ("aro_419").

Fixes deployment error: "The selected VM size cannot boot Hypervisor Generation '1'."

Changes behaviour to match upstream by selecting Gen2 preferentially for supported VMs.

Fixes [ARO-22037](https://issues.redhat.com/browse/ARO-22037)