### PR TITLE
Update aro-dnsmasq-pre.sh.gotmpl

### DIFF
--- a/pkg/installer/dnsmasq/scripts/aro-dnsmasq-pre.sh.gotmpl
+++ b/pkg/installer/dnsmasq/scripts/aro-dnsmasq-pre.sh.gotmpl
@@ -12,13 +12,13 @@ NODEIP=$(/sbin/ip --json route get 168.63.129.16 | /bin/jq -r ".[].prefsrc")
 
 if [ "$NODEIP" != "" ]; then
     /bin/cp -Z /etc/resolv.conf /etc/resolv.conf.dnsmasq
-    SEARCHDOMAIN=$(awk '/^search/ { print $2; }' /etc/resolv.conf.dnsmasq)
+    SEARCHDOMAIN=$(awk '/^search/ { $1=""; print $0 }' /etc/resolv.conf.dnsmasq)
     /bin/chmod 0744 /etc/resolv.conf.dnsmasq
 
     cat <<EOF | /bin/tee /etc/NetworkManager/conf.d/aro-dns.conf
 # Added by dnsmasq.service
 [global-dns]
-searches=$SEARCHDOMAIN
+searches=$(for i in ${SEARCHDOMAIN}; do echo -n ${i},; done)
 
 [global-dns-domain-*]
 servers=$NODEIP


### PR DESCRIPTION
Update aro-dnsmasq-pre.sh to support more than one search domains - update AWK to exclude first line and include the rest, rather than than only print column 2, as well as update search domain list entry at aro-dns.conf to enable multiple search terms.


### Which issue this PR addresses:

Issue/Fixes: [https://github.com/Azure/ARO-RP/issues/4485](https://github.com/Azure/ARO-RP/issues/4485)
Issue/Fixes: [https://issues.redhat.com/browse/ARO-22870](https://issues.redhat.com/browse/ARO-22870) (this includes detailed testing/implementation and validation steps for this change as well and is accessible externally)

### What this PR does / why we need it:

Problem: ARO clusters cannot utilize more than one search cluster-wide which is the default `cluster.domain` generated entry. If any search in the list for a manual network configuration is injected that is NOT this cluster.domain address this value will override the search parameter for the cluster, breaking traffic flow. `cluster.domain` is required for healthy lookups, but secondary domains may be needed for streamlined traffic handling. 

This change adjusts the awk logic in selecting the search terms from "Select the first search entry in the list from the cloned /etc/resolv.conf.dnsmasq file before building the permanent /etc/resolv.conf file" to enable this value to get set with any/all search domains specified at install time (or day-2).. Additionally the aro-dns.conf file requires a list type to function with multiple values, and so the iteration must be used to facilitiate multiple value injects.

### Test plan for issue:

How did you test that this PR works?

- Cloned the script out, modified the target files from /etc/resolv.conf.dnsmasq to /tmp/resolv.conf.dnsmasq and /tmp/resolv.conf to avoid modifying live cluster config + executed. Validated the results include the test search parameters injected into /etc/NetworkManager/system-connections/eth0.nmconnection which specify additional test domains. 

- After validating, modified the live `/usr/local/bin/aro-dnsmasq-pre.sh` script build after resetting `/etc/resolv.conf` from `/etc/resolv.conf.dnsmasq` and re-executing the script.
- Subsequent tests involved updates to /etc/NetworkManager/system-connections/eth0.nmconnection to set values explicitly + restarting hosts to enable flow. (This makes machine-config unhappy because on-disk state has changed but this is inconsequential for testing). 

- Are there unit tests?
No

- Are there integration/e2e tests?
No

- If it is not possible to write automated tests, explain why and document how
  to manually test and verify the feature.

The change can be tested easily by making the adjustments on the existing target script: 
`/usr/local/bin/aro-dnsmasq-pre.sh` and either comment out the `cp -Z /etc/resolv.conf /etc/resolv.conf.dnsmasq` line or copy the /etc/resolv.conf.dnsmasq file back over /etc/resolv.conf to start so that we reset our template back to defaults, then simply run the script:

`/usr/local/bin/aro-dnsmasq-pre.sh` which will update `/etc/NetworkManager/conf.d/aro-dns.conf` and subsequently reload /etc/resolv.conf which will now reflect the desired multi-search parameter config. 


### Is there any documentation that needs to be updated for this PR?

This is part of an effort to review/consider updating search domains within ARO - it is likely a docs update will be needed after review.

### How do you know this will function as expected in production? 

- limited local testing is promising, review and vetting is required. 