### PR TITLE
Use Gen1 VM images by default, switch to Gen2 only when required

### DIFF
--- a/cmd/aro/ensurebuildtag_aro.go
+++ b/cmd/aro/ensurebuildtag_aro.go
@@ -1,5 +1,4 @@
 //go:build aro
-// +build aro
 
 package main
 

--- a/deps.go
+++ b/deps.go
@@ -1,5 +1,4 @@
 //go:build tools
-// +build tools
 
 package main
 

--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
-	"sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -283,7 +282,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 						BaseDomainResourceGroupName: resourceGroup,
 						DefaultMachinePlatform: &azuretypes.MachinePool{
 							Identity: &azuretypes.VMIdentity{
-								Type: v1beta1.VMIdentityNone,
+								Type: capzazure.VMIdentityNone,
 							},
 						},
 					},

--- a/pkg/installer/generateconfig_test.go
+++ b/pkg/installer/generateconfig_test.go
@@ -52,10 +52,10 @@ func TestVMNetworkingType(t *testing.T) {
 
 func TestDetermineSkuSupportsV2Only(t *testing.T) {
 	for _, tt := range []struct {
-		name        string
-		sku         *mgmtcompute.ResourceSku
-		wantResult  bool
-		wantErr     string
+		name       string
+		sku        *mgmtcompute.ResourceSku
+		wantResult bool
+		wantErr    string
 	}{
 		{
 			name: "sku supports both V1 and V2, does not require V2",

--- a/pkg/util/mocks/azureclient/keyvault/keyvault.go
+++ b/pkg/util/mocks/azureclient/keyvault/keyvault.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	keyvault "github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
 	gomock "go.uber.org/mock/gomock"
+
+	keyvault "github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
 )
 
 // MockBaseClient is a mock of BaseClient interface.

--- a/pkg/util/mocks/azureclient/mgmt/compute/compute.go
+++ b/pkg/util/mocks/azureclient/mgmt/compute/compute.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	gomock "go.uber.org/mock/gomock"
+
+	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 )
 
 // MockDisksClient is a mock of DisksClient interface.

--- a/pkg/util/mocks/azureclient/mgmt/features/features.go
+++ b/pkg/util/mocks/azureclient/mgmt/features/features.go
@@ -13,9 +13,10 @@ import (
 	context "context"
 	reflect "reflect"
 
+	gomock "go.uber.org/mock/gomock"
+
 	features "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-07-01/features"
 	autorest "github.com/Azure/go-autorest/autorest"
-	gomock "go.uber.org/mock/gomock"
 )
 
 // MockDeploymentsClient is a mock of DeploymentsClient interface.

--- a/pkg/util/mocks/azureclient/mgmt/network/network.go
+++ b/pkg/util/mocks/azureclient/mgmt/network/network.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 	gomock "go.uber.org/mock/gomock"
+
+	network "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2020-08-01/network"
 )
 
 // MockInterfacesClient is a mock of InterfacesClient interface.

--- a/pkg/util/mocks/env/env.go
+++ b/pkg/util/mocks/env/env.go
@@ -16,10 +16,11 @@ import (
 	net "net"
 	reflect "reflect"
 
+	gomock "go.uber.org/mock/gomock"
+
 	azidentity "github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2020-06-01/compute"
 	autorest "github.com/Azure/go-autorest/autorest"
-	gomock "go.uber.org/mock/gomock"
 
 	env "github.com/openshift/installer-aro-wrapper/pkg/env"
 	azureclient "github.com/openshift/installer-aro-wrapper/pkg/util/azureclient"

--- a/pkg/util/mocks/keyvault/keyvault.go
+++ b/pkg/util/mocks/keyvault/keyvault.go
@@ -15,8 +15,9 @@ import (
 	x509 "crypto/x509"
 	reflect "reflect"
 
-	keyvault "github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
 	gomock "go.uber.org/mock/gomock"
+
+	keyvault "github.com/Azure/azure-sdk-for-go/services/keyvault/v7.0/keyvault"
 
 	keyvault0 "github.com/openshift/installer-aro-wrapper/pkg/util/keyvault"
 )

--- a/pkg/util/mocks/refreshable/refreshable.go
+++ b/pkg/util/mocks/refreshable/refreshable.go
@@ -12,8 +12,9 @@ package mock_refreshable
 import (
 	reflect "reflect"
 
-	autorest "github.com/Azure/go-autorest/autorest"
 	gomock "go.uber.org/mock/gomock"
+
+	autorest "github.com/Azure/go-autorest/autorest"
 )
 
 // MockAuthorizer is a mock of Authorizer interface.

--- a/pkg/util/mocks/storage/storage.go
+++ b/pkg/util/mocks/storage/storage.go
@@ -13,8 +13,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	armstorage "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 	gomock "go.uber.org/mock/gomock"
+
+	armstorage "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage"
 
 	azblob "github.com/openshift/installer-aro-wrapper/pkg/util/azureclient/azuresdk/azblob"
 )


### PR DESCRIPTION
Change the HyperV generation image selection logic to default to Gen1images (aro_419) instead of Gen2 (419-v2). Gen2 images are now onlyused when a VM SKU exclusively supports V2 and does not support V1.

Fixes [ARO-22037](https://issues.redhat.com/browse/ARO-22037)