### PR TITLE
[ARO-27905] Cluster install broken in non-zonal regions

### DIFF
--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -119,7 +119,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 		workerZones = []string{""}
 		controlPlaneZones = []string{""}
 	} else {
-		controlPlaneZones, workerZones, _, err = azurezones.NewManager(false).DetermineAvailabilityZones(masterSKU, workerSKU)
+		controlPlaneZones, workerZones, err = azurezones.NewManager(false).DetermineAvailabilityZones(masterSKU, workerSKU)
 		if err != nil {
 			return nil, nil, errors.WithStack(err)
 		}

--- a/pkg/util/azurezones/azurezones.go
+++ b/pkg/util/azurezones/azurezones.go
@@ -40,7 +40,7 @@ func (m *availabilityZoneManager) FilterZones(zones []string) []string {
 	return zones
 }
 
-func (m *availabilityZoneManager) DetermineAvailabilityZones(controlPlaneSKU, workerSKU *armcompute.ResourceSKU) ([]string, []string, []string, error) {
+func (m *availabilityZoneManager) DetermineAvailabilityZones(controlPlaneSKU, workerSKU *armcompute.ResourceSKU) ([]string, []string, error) {
 	controlPlaneZones := computeskus.Zones(controlPlaneSKU)
 	workerZones := computeskus.Zones(workerSKU)
 
@@ -62,26 +62,21 @@ func (m *availabilityZoneManager) DetermineAvailabilityZones(controlPlaneSKU, wo
 
 	if (len(controlPlaneZones) == 0 && len(workerZones) > 0) ||
 		(len(workerZones) == 0 && len(controlPlaneZones) > 0) {
-		return nil, nil, nil, fmt.Errorf("cluster creation with mix of zonal and non-zonal resources is unsupported (control plane zones: %d, worker zones: %d)", len(controlPlaneZones), len(workerZones))
+		return nil, nil, fmt.Errorf("cluster creation with mix of zonal and non-zonal resources is unsupported (control plane zones: %d, worker zones: %d)", len(controlPlaneZones), len(workerZones))
 	}
 
-	// Once we've removed the expanded AZs (if applicable), get the super-set of
-	// AZs for deploying PIPs/Frontend IPs in
-	allAvailableZones := slices.Concat(controlPlaneZones, workerZones)
-	slices.Sort(allAvailableZones)
-	allAvailableZones = slices.Compact(allAvailableZones)
-	if len(allAvailableZones) == 0 {
-		allAvailableZones = []string{}
+	// we now know that if either control plane or worker zones is empty, then the other one must be as well.
+	// we return the config for non-zonal installation
+	if len(controlPlaneZones) == 0 {
+		return []string{""}, []string{""}, nil
 	}
 
-	// We handle the case where regions have no zones or >= zones than replicas,
+	// We handle the case where regions have >= zones than replicas,
 	// but not when replicas > zones. We (currently) only support 3 control
 	// plane replicas and Azure AZs will always be a minimum of 3, see
 	// https://azure.microsoft.com/en-us/blog/our-commitment-to-expand-azure-availability-zones-to-more-regions/
-	if len(controlPlaneZones) == 0 {
-		controlPlaneZones = []string{}
-	} else if len(controlPlaneZones) < CONTROL_PLANE_MACHINE_COUNT {
-		return nil, nil, nil, fmt.Errorf("control plane SKU '%s' only available in %d zones, need %d", *controlPlaneSKU.Name, len(controlPlaneZones), CONTROL_PLANE_MACHINE_COUNT)
+	if len(controlPlaneZones) < CONTROL_PLANE_MACHINE_COUNT {
+		return nil, nil, fmt.Errorf("control plane SKU '%s' only available in %d zones, need %d", *controlPlaneSKU.Name, len(controlPlaneZones), CONTROL_PLANE_MACHINE_COUNT)
 	} else if len(controlPlaneZones) >= CONTROL_PLANE_MACHINE_COUNT {
 		// Pick lower zones first
 		controlPlaneZones = controlPlaneZones[:CONTROL_PLANE_MACHINE_COUNT]
@@ -95,11 +90,9 @@ func (m *availabilityZoneManager) DetermineAvailabilityZones(controlPlaneSKU, wo
 	// such, prevent situations where 2 workers may be deployed on one zone and
 	// 1 on another, even though OpenShift treats that as a theoretically valid
 	// configuration.
-	if len(workerZones) == 0 {
-		workerZones = []string{}
-	} else if len(workerZones) < 3 {
-		return nil, nil, nil, fmt.Errorf("worker SKU '%s' only available in %d zones, need %d", *workerSKU.Name, len(workerZones), 3)
+	if len(workerZones) < 3 {
+		return nil, nil, fmt.Errorf("worker SKU '%s' only available in %d zones, need %d", *workerSKU.Name, len(workerZones), 3)
 	}
 
-	return controlPlaneZones, workerZones, allAvailableZones, nil
+	return controlPlaneZones, workerZones, nil
 }

--- a/pkg/util/azurezones/azurezones_test.go
+++ b/pkg/util/azurezones/azurezones_test.go
@@ -21,7 +21,6 @@ func TestDetermineZones(t *testing.T) {
 		workerSkuZones        []string
 		wantControlPlaneZones []string
 		wantWorkerZones       []string
-		wantPIPZones          []string
 		allowExpandedAZs      bool
 
 		wantErr string
@@ -36,17 +35,15 @@ func TestDetermineZones(t *testing.T) {
 			name:                  "non-zonal",
 			controlPlaneSkuZones:  []string{},
 			workerSkuZones:        []string{},
-			wantControlPlaneZones: []string{},
-			wantWorkerZones:       []string{},
-			wantPIPZones:          []string{},
+			wantControlPlaneZones: []string{""},
+			wantWorkerZones:       []string{""},
 		},
 		{
 			name:                  "non-zonal but API returns a nil slice",
 			controlPlaneSkuZones:  nil,
 			workerSkuZones:        nil,
-			wantControlPlaneZones: []string{},
-			wantWorkerZones:       []string{},
-			wantPIPZones:          []string{},
+			wantControlPlaneZones: []string{""},
+			wantWorkerZones:       []string{""},
 		},
 		{
 			name:                 "non-zonal control plane, zonal workers",
@@ -66,7 +63,6 @@ func TestDetermineZones(t *testing.T) {
 			workerSkuZones:        []string{"1", "2", "3"},
 			wantControlPlaneZones: []string{"1", "2", "3"},
 			wantWorkerZones:       []string{"1", "2", "3"},
-			wantPIPZones:          []string{"1", "2", "3"},
 		},
 		{
 			name:                  "region with 4 availability zones, expanded AZs, control plane uses first 3, workers use all",
@@ -75,7 +71,6 @@ func TestDetermineZones(t *testing.T) {
 			workerSkuZones:        []string{"1", "2", "3", "4"},
 			wantControlPlaneZones: []string{"1", "2", "3"},
 			wantWorkerZones:       []string{"1", "2", "3", "4"},
-			wantPIPZones:          []string{"1", "2", "3", "4"},
 		},
 		{
 			name:                  "region with 4 availability zones, basic AZs only, control plane and workers use 3",
@@ -84,7 +79,6 @@ func TestDetermineZones(t *testing.T) {
 			workerSkuZones:        []string{"1", "2", "3", "4"},
 			wantControlPlaneZones: []string{"1", "2", "3"},
 			wantWorkerZones:       []string{"1", "2", "3"},
-			wantPIPZones:          []string{"1", "2", "3"},
 		},
 		{
 			name:                 "not enough control plane zones",
@@ -117,7 +111,6 @@ func TestDetermineZones(t *testing.T) {
 			workerSkuZones:        []string{"1", "2", "3", "4"},
 			wantControlPlaneZones: []string{"1", "2", "4"},
 			wantWorkerZones:       []string{"1", "2", "3", "4"},
-			wantPIPZones:          []string{"1", "2", "3", "4"},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
@@ -138,7 +131,7 @@ func TestDetermineZones(t *testing.T) {
 				allowExpandedAvailabilityZones: tt.allowExpandedAZs,
 			}
 
-			controlPlaneZones, workerZones, PIPZones, err := m.DetermineAvailabilityZones(controlPlaneSku, workerSku)
+			controlPlaneZones, workerZones, err := m.DetermineAvailabilityZones(controlPlaneSku, workerSku)
 			if err != nil && err.Error() != tt.wantErr {
 				t.Error("wantErr", cmp.Diff(tt.wantErr, err))
 			}
@@ -149,10 +142,6 @@ func TestDetermineZones(t *testing.T) {
 
 			if !reflect.DeepEqual(workerZones, tt.wantWorkerZones) {
 				t.Error("workerZones", cmp.Diff(tt.wantWorkerZones, workerZones))
-			}
-
-			if !reflect.DeepEqual(PIPZones, tt.wantPIPZones) {
-				t.Error("PIPZones", cmp.Diff(tt.wantPIPZones, PIPZones))
 			}
 		})
 	}


### PR DESCRIPTION
When installing a cluster in a non-zonal region it fails with the error:

```
Deployment template validation failed: 'The value for the template parameter 'controlPlaneZones' at line '1' and column '181' is not provided. 
```

This is because we are passing an empty slice `[]string{}` as the value for the `controlplanezones` parameter in the arm template. This behaviour was introduced in https://github.com/openshift/installer-aro-wrapper/pull/408/ .
Instead, to facilitate a non-zonal installation, we must pass a slice with an empty string `[]string{""}` instead.

### Summary of changes

- make `DetermineAvailabilityZones` return `[]string{""}` when non-zonal installation is wanted
- remove unneccessary return parameter `allAvailabilityZones` from `DetermineAvailabilityZones`

