### PR TITLE
[ARO-27905] fix undefined controlPlaneZones parameter, add unit test

### DIFF
--- a/pkg/installer/deployresources.go
+++ b/pkg/installer/deployresources.go
@@ -58,7 +58,7 @@ func (m *manager) deployResourceTemplate(ctx context.Context) error {
 	}
 
 	params["controlPlaneZones"] = map[string]interface{}{
-		"value": installConfig.Config.ControlPlane.Platform.Azure.Zones,
+		"value": convertControlPlaneZonesToArmParameter(installConfig.Config.ControlPlane.Platform.Azure.Zones),
 	}
 
 	t := &arm.Template{
@@ -86,11 +86,27 @@ func (m *manager) deployResourceTemplate(ctx context.Context) error {
 // Handle the case where nonzonal resources actually need to have an empty zone
 // param instead of {""}
 func zones(installConfig *installconfig.InstallConfig) *[]string {
-	if reflect.DeepEqual(installConfig.Config.ControlPlane.Platform.Azure.Zones, []string{""}) || reflect.DeepEqual(installConfig.Config.ControlPlane.Platform.Azure.Zones, []string{}) {
+	if reflect.DeepEqual(installConfig.Config.ControlPlane.Platform.Azure.Zones, []string{""}) ||
+		reflect.DeepEqual(installConfig.Config.ControlPlane.Platform.Azure.Zones, []string{}) {
 		// Non-zonal
 		return nil
 	} else {
 		// Use the zones we have been specified
 		return &[]string{"[parameters('controlPlaneZones')[copyIndex(0)]]"}
 	}
+}
+
+// convertControlPlaneZonesToArmParameter makes sure that an empty zone slice
+// gets changed to []string{""}, so it can be safely passed in via the arm
+// parameter
+func convertControlPlaneZonesToArmParameter(in []string) []string {
+	if in == nil {
+		return []string{""}
+	}
+
+	if reflect.DeepEqual(in, []string{}) {
+		return []string{""}
+	}
+
+	return in
 }

--- a/pkg/installer/deployresources_test.go
+++ b/pkg/installer/deployresources_test.go
@@ -66,3 +66,40 @@ func TestZones(t *testing.T) {
 		})
 	}
 }
+
+func Test_convertControlPlaneZonesToArmParameter(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "empty slice is converted to slice with empty string",
+			in:   []string{},
+			want: []string{""},
+		},
+		{
+			name: "nil slice is returned as-is",
+			in:   nil,
+			want: []string{""},
+		},
+		{
+			name: "non-empty zone slice is returned unchanged",
+			in:   []string{"1", "2", "3"},
+			want: []string{"1", "2", "3"},
+		},
+		{
+			name: "slice with empty string is returned unchanged",
+			in:   []string{""},
+			want: []string{""},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertControlPlaneZonesToArmParameter(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("convertControlPlaneZonesToArmParameter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -116,8 +116,8 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 
 	// centraluseuap reports one zone, so we need to perform a non-zonal install in that region
 	if strings.EqualFold(m.oc.Location, "centraluseuap") {
-		workerZones = []string{""}
-		controlPlaneZones = []string{""}
+		workerZones = []string{}
+		controlPlaneZones = []string{}
 	} else {
 		controlPlaneZones, workerZones, _, err = azurezones.NewManager(false).DetermineAvailabilityZones(masterSKU, workerSKU)
 		if err != nil {


### PR DESCRIPTION
- Adding a new function to convert the empty `[]string{}` to `[]string{""}`, so it can be unit tested
- Changing the non-zonal value for the special handling of "centraluseuap" to what `DetermineAvailabilityZones` would return, so we don't have two different null values to deal with
- add simple unit test.