### PR TITLE
fix non-zonal install issue

### DIFF
--- a/pkg/installer/deployresources.go
+++ b/pkg/installer/deployresources.go
@@ -87,7 +87,8 @@ func (m *manager) deployResourceTemplate(ctx context.Context) error {
 // param instead of {""}
 func zones(installConfig *installconfig.InstallConfig) *[]string {
 	if reflect.DeepEqual(installConfig.Config.ControlPlane.Platform.Azure.Zones, []string{""}) ||
-		reflect.DeepEqual(installConfig.Config.ControlPlane.Platform.Azure.Zones, []string{}) {
+		reflect.DeepEqual(installConfig.Config.ControlPlane.Platform.Azure.Zones, []string{}) ||
+		installConfig.Config.ControlPlane.Platform.Azure.Zones == nil {
 		// Non-zonal
 		return nil
 	} else {

--- a/pkg/installer/deployresources_test.go
+++ b/pkg/installer/deployresources_test.go
@@ -27,6 +27,11 @@ func TestZones(t *testing.T) {
 			wantMaster: nil,
 		},
 		{
+			name:       "non-zonal, nil",
+			zones:      nil,
+			wantMaster: nil,
+		},
+		{
 			name:       "non-zonal",
 			zones:      []string{""},
 			wantMaster: nil,


### PR DESCRIPTION
- when installconfig is generated and saved to the "graph", empty slices in the config are being changed to `nil`
- This causes our deploy logic to not realize that a cluster is non-zonal
- This adds the additional case to `zones()` and adds a new unit testcase to cover this.