### PR TITLE
Fix Dockerfile `FROM` directive for local image builds

### DIFF
--- a/Dockerfile.aro
+++ b/Dockerfile.aro
@@ -3,8 +3,8 @@
 ARG REGISTRY=registry.access.redhat.com
 ARG REPOSITORY=ubi9/ubi-minimal
 ARG TAG=latest
-ARG BUILDER_REGISTRY=registry.ci.openshift.org
-ARG BUILDER_REPOSITORY=ocp/builder
+ARG BUILDER_REGISTRY=arointsvc.azurecr.io
+ARG BUILDER_REPOSITORY=openshift-release-dev/golang-builder--partner-share
 ARG BUILDER_TAG=rhel-9-golang-1.24-openshift-4.20
 FROM ${BUILDER_REGISTRY}/${BUILDER_REPOSITORY}:${BUILDER_TAG} AS builder
 

--- a/Makefile
+++ b/Makefile
@@ -14,15 +14,16 @@ else
 endif
 
 # default to registry.access.redhat.com for build images on local builds and CI builds without $RP_IMAGE_ACR set.
+BUILDER_REPOSITORY = openshift-release-dev/golang-builder--partner-share
 ifeq ($(RP_IMAGE_ACR),arointsvc)
 	REGISTRY = arointsvc.azurecr.io
-	BUILDER_REGISTRY = arointsvc.azurecr.io/openshift-release-dev/golang-builder--partner-share
+	BUILDER_REGISTRY = arointsvc.azurecr.io
 else ifeq ($(RP_IMAGE_ACR),arosvc)
 	REGISTRY = arosvc.azurecr.io
-	BUILDER_REGISTRY = arosvc.azurecr.io/openshift-release-dev/golang-builder--partner-share
+	BUILDER_REGISTRY = arosvc.azurecr.io
 else
 	REGISTRY ?= registry.access.redhat.com
-	BUILDER_REGISTRY ?= quay.io/openshift-release-dev/golang-builder--partner-share
+	BUILDER_REGISTRY ?= quay.io
 endif
 
 ARO_IMAGE ?= $(ARO_IMAGE_BASE):$(VERSION)
@@ -49,7 +50,7 @@ generate: install-tools
 .PHONY: image-aro
 image-aro:
 	docker pull $(REGISTRY)/ubi9/ubi-minimal
-	docker build --platform=linux/amd64 --network=host --no-cache -f Dockerfile.aro -t $(ARO_IMAGE) --build-arg REGISTRY=$(REGISTRY) --build-arg BUILDER_REGISTRY=$(BUILDER_REGISTRY) .
+	docker build --platform=linux/amd64 --network=host --no-cache -f Dockerfile.aro -t $(ARO_IMAGE) --build-arg REGISTRY=$(REGISTRY) --build-arg BUILDER_REGISTRY=$(BUILDER_REGISTRY) --build-arg BUILDER_REPOSITORY=$(BUILDER_REPOSITORY) .
 
 .PHONY: publish-image-aro
 publish-image-aro: image-aro


### PR DESCRIPTION
The added repository component with default value of `ocp/builder` was breaking image builds locally because the Makefile wasn't updated to align with it. I also added a correct default value.

I intend to cherry pick this to release-4.21 through release-4.18 after merge. I don't think anyone uses main much nowadays, but I figured I'd start by putting the fix here just in case.