### PR TITLE
fix(udr): ensure node-image-pull.service starts after ARO DNS services on bootstrap

### DIFF
--- a/pkg/installer/dnsmasq/dnsmasq_config.go
+++ b/pkg/installer/dnsmasq/dnsmasq_config.go
@@ -4,6 +4,10 @@ package dnsmasq
 // Licensed under the Apache License 2.0.
 
 import (
+	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
+
+	"github.com/Azure/go-autorest/autorest/to"
+
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 
@@ -24,6 +28,26 @@ func CreatednsmasqIgnitionFiles(bootstrapAsset *bootstrap.Bootstrap, installConf
 	}
 	bootstrapAsset.Config.Storage.Files = bootstrapfiles.ReplaceOrAppend(bootstrapAsset.Config.Storage.Files, dnsmasqIgnConfig.Storage.Files)
 	bootstrapAsset.Config.Systemd.Units = bootstrapfiles.ReplaceOrAppendSystemd(bootstrapAsset.Config.Systemd.Units, dnsmasqIgnConfig.Systemd.Units)
+
+	// Add a drop-in for node-image-pull.service to ensure it starts after dnsmasq
+	// and aro-etchosts-resolver have configured DNS and /etc/hosts. Required for
+	// 4.19+ where node-image-pull.service (from the base OS image) pulls the
+	// OCP release image from ACR during bootstrap.
+	nodeImagePullDropin := "[Unit]\nAfter=dnsmasq.service\nAfter=aro-etchosts-resolver.service\n"
+	bootstrapAsset.Config.Systemd.Units = bootstrapfiles.ReplaceOrAppendSystemd(
+		bootstrapAsset.Config.Systemd.Units,
+		[]igntypes.Unit{
+			{
+				Name: "node-image-pull.service",
+				Dropins: []igntypes.Dropin{
+					{
+						Name:     "10-aro-dns-ordering.conf",
+						Contents: to.StringPtr(nodeImagePullDropin),
+					},
+				},
+			},
+		},
+	)
 
 	dnsmasqMasterMachineConfig, err := MachineConfig(installConfig.Config.ClusterDomain(), dnsConfig.APIIntIP, dnsConfig.IngressIP, "master", dnsConfig.GatewayDomains, dnsConfig.GatewayPrivateEndpointIP)
 	if err != nil {

--- a/pkg/installer/dnsmasq/dnsmasq_config.go
+++ b/pkg/installer/dnsmasq/dnsmasq_config.go
@@ -4,10 +4,6 @@ package dnsmasq
 // Licensed under the Apache License 2.0.
 
 import (
-	igntypes "github.com/coreos/ignition/v2/config/v3_2/types"
-
-	"github.com/Azure/go-autorest/autorest/to"
-
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
 	"github.com/openshift/installer/pkg/asset/installconfig"
 
@@ -28,26 +24,6 @@ func CreatednsmasqIgnitionFiles(bootstrapAsset *bootstrap.Bootstrap, installConf
 	}
 	bootstrapAsset.Config.Storage.Files = bootstrapfiles.ReplaceOrAppend(bootstrapAsset.Config.Storage.Files, dnsmasqIgnConfig.Storage.Files)
 	bootstrapAsset.Config.Systemd.Units = bootstrapfiles.ReplaceOrAppendSystemd(bootstrapAsset.Config.Systemd.Units, dnsmasqIgnConfig.Systemd.Units)
-
-	// Add a drop-in for node-image-pull.service to ensure it starts after dnsmasq
-	// and aro-etchosts-resolver have configured DNS and /etc/hosts. Required for
-	// 4.19+ where node-image-pull.service (from the base OS image) pulls the
-	// OCP release image from ACR during bootstrap.
-	nodeImagePullDropin := "[Unit]\nAfter=dnsmasq.service\nAfter=aro-etchosts-resolver.service\n"
-	bootstrapAsset.Config.Systemd.Units = bootstrapfiles.ReplaceOrAppendSystemd(
-		bootstrapAsset.Config.Systemd.Units,
-		[]igntypes.Unit{
-			{
-				Name: "node-image-pull.service",
-				Dropins: []igntypes.Dropin{
-					{
-						Name:     "10-aro-dns-ordering.conf",
-						Contents: to.StringPtr(nodeImagePullDropin),
-					},
-				},
-			},
-		},
-	)
 
 	dnsmasqMasterMachineConfig, err := MachineConfig(installConfig.Config.ClusterDomain(), dnsConfig.APIIntIP, dnsConfig.IngressIP, "master", dnsConfig.GatewayDomains, dnsConfig.GatewayPrivateEndpointIP)
 	if err != nil {

--- a/pkg/installer/etchost/etchosts.go
+++ b/pkg/installer/etchost/etchosts.go
@@ -81,6 +81,7 @@ cmp "${TEMP_FILE}" "${HOSTS_FILE}" || cp -f "${TEMP_FILE}" "${HOSTS_FILE}"
 var aroUnitTemplate = template.Must(template.New("etchostservice").Parse(`[Unit]
 Description=One shot service that appends static domains to etchosts
 Before=network-online.target
+Before=node-image-pull.service
 
 [Service]
 # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts

--- a/pkg/installer/etchost/etchosts.go
+++ b/pkg/installer/etchost/etchosts.go
@@ -87,7 +87,7 @@ Before=network-online.target
 ExecStart=/bin/bash /usr/local/bin/{{ .ScriptFileName }}
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=network-online.target
 `))
 
 func GenerateEtcHostsAROConf(clusterDomain string, apiIntIP string, gatewayDomains []string, gatewayPrivateEndpointIP string) ([]byte, error) {

--- a/pkg/installer/storage_files_testdata.go
+++ b/pkg/installer/storage_files_testdata.go
@@ -241,6 +241,7 @@ spec:
           [Unit]
           Description=One shot service that appends static domains to etchosts
           Before=network-online.target
+          Before=node-image-pull.service
 
           [Service]
           # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts
@@ -361,6 +362,7 @@ spec:
           [Unit]
           Description=One shot service that appends static domains to etchosts
           Before=network-online.target
+          Before=node-image-pull.service
 
           [Service]
           # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts

--- a/pkg/installer/storage_files_testdata.go
+++ b/pkg/installer/storage_files_testdata.go
@@ -247,7 +247,7 @@ spec:
           ExecStart=/bin/bash /usr/local/bin/aro-etchosts-resolver.sh
 
           [Install]
-          WantedBy=multi-user.target
+          WantedBy=network-online.target
         enabled: true
         name: aro-etchosts-resolver.service
   extensions: null
@@ -367,7 +367,7 @@ spec:
           ExecStart=/bin/bash /usr/local/bin/aro-etchosts-resolver.sh
 
           [Install]
-          WantedBy=multi-user.target
+          WantedBy=network-online.target
         enabled: true
         name: aro-etchosts-resolver.service
   extensions: null

--- a/pkg/installer/systemd_files_testdata.go
+++ b/pkg/installer/systemd_files_testdata.go
@@ -7,6 +7,7 @@ var expectedIgnitionServiceContents = map[string]string{
 	"aro-etchosts-resolver.service": `[Unit]
 Description=One shot service that appends static domains to etchosts
 Before=network-online.target
+Before=node-image-pull.service
 
 [Service]
 # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts

--- a/pkg/installer/systemd_files_testdata.go
+++ b/pkg/installer/systemd_files_testdata.go
@@ -13,7 +13,7 @@ Before=network-online.target
 ExecStart=/bin/bash /usr/local/bin/aro-etchosts-resolver.sh
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=network-online.target
 `,
 	"dnsmasq.service": `
 [Unit]


### PR DESCRIPTION
ARO UDR clusters (outboundType=UserDefinedRouting) fail to install on OCP 4.21 with OSProvisioningTimedOut while the same configuration successfully installs OCP 4.18 UDR cluster. The failure is caused by a new systemd service introduced in [4.19+ ](https://redhat.atlassian.net/browse/OCPBUGS-79503)called node-image-pull.service, which is baked into the base RHCOS image and not injected by the ARO installer. This service runs during bootstrap boot and pulls the OCP release image from ACR. On UDR clusters, ACR is only reachable via the ARO gateway private endpoint, whose IP is written into /etc/hosts by aro-etchosts-resolver.service and resolved via dnsmasq. The failure log confirms the race: podman resolved arostgsvc.azurecr.io to its public IP xx.xx.xx.xx and timed out with "dial tcp xx.xx.xx.xx:443: i/o timeout", proving that /etc/hosts had not yet been updated when node-image-pull.service started.

RP logs of the failed install.

``
7/16/2026, 6:13:22.02028 AM	Jul 16 06:13:17 edison-udr-421-6jrpj-bootstrap node-image-pull.sh[2963]: Failed to query release image; retrying...
7/16/2026, 6:13:22.020136 AM	Jul 16 06:13:17 edison-udr-421-6jrpj-bootstrap podman[3196]: 2026-07-16 06:13:17.0084417 +0000 UTC m=+123.176225201 image pull-error  arostgsvc.azurecr.io/openshift-release-dev/ocp-release@sha256:52e54316796bcb6f31212edf0c0c4f89d0383232371d5d0a5cfed1513198b94b initializing source docker://arostgsvc.azurecr.io/openshift-release-dev/ocp-release@sha256:52e54316796bcb6f31212edf0c0c4f89d0383232371d5d0a5cfed1513198b94b: pinging container registry arostgsvc.azurecr.io: Get "https://arostgsvc.azurecr.io/v2/": dial tcp xx.xx.xx.xx:443: i/o timeout
7/16/2026, 6:13:22.020001 AM	Jul 16 06:13:17 edison-udr-421-6jrpj-bootstrap node-image-pull.sh[3196]: Error: initializing source docker://arostgsvc.azurecr.io/openshift-release-dev/ocp-release@sha256:52e54316796bcb6f31212edf0c0c4f89d0383232371d5d0a5cfed1513198b94b: pinging container registry arostgsvc.azurecr.io: Get "https://arostgsvc.azurecr.io/v2/": dial tcp xx.xx.xx.xx:443: i/o timeout
``

The root cause is a systemd ordering gap in aro-etchosts-resolver.service. The service already declared Before=network-online.target, but its Install section used WantedBy=multi-user.target. Because of this, systemd had no obligation to pull aro-etchosts-resolver.service into the activation chain for network-online.target. node-image-pull.service declares After=network-online.target with no awareness of ARO-specific DNS services, so it could start before /etc/hosts was populated. This was not a problem in OCP 4.18 because node-image-pull.service did not exist in that release and no ACR pull was ever attempted at bootstrap boot time.

Assisted by Copilot.