### PR TITLE
fix: Add missing Type=oneshot. systemd now waits for  script aro-etchosts-resolver.sh

### DIFF
--- a/pkg/installer/etchost/etchosts.go
+++ b/pkg/installer/etchost/etchosts.go
@@ -84,6 +84,7 @@ Before=network-online.target
 Before=node-image-pull.service
 
 [Service]
+Type=oneshot
 # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts
 ExecStart=/bin/bash /usr/local/bin/{{ .ScriptFileName }}
 

--- a/pkg/installer/storage_files_testdata.go
+++ b/pkg/installer/storage_files_testdata.go
@@ -244,6 +244,7 @@ spec:
           Before=node-image-pull.service
 
           [Service]
+          Type=oneshot
           # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts
           ExecStart=/bin/bash /usr/local/bin/aro-etchosts-resolver.sh
 
@@ -365,6 +366,7 @@ spec:
           Before=node-image-pull.service
 
           [Service]
+          Type=oneshot
           # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts
           ExecStart=/bin/bash /usr/local/bin/aro-etchosts-resolver.sh
 

--- a/pkg/installer/systemd_files_testdata.go
+++ b/pkg/installer/systemd_files_testdata.go
@@ -10,6 +10,7 @@ Before=network-online.target
 Before=node-image-pull.service
 
 [Service]
+Type=oneshot
 # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts
 ExecStart=/bin/bash /usr/local/bin/aro-etchosts-resolver.sh
 


### PR DESCRIPTION
Add missing Type=oneshot. systemd now waits for  script aro-etchosts-resolver.sh to exit before the service is "active", guaranteeing /etc/hosts is written before network-online.target activates and node-image-pull.service starts.

The key here is the intent of the original author of the service which is to be a "One shot service" as seen below.

pkg\installer\etchost\etchosts.go
```
var aroUnitTemplate = template.Must(template.New("etchostservice").Parse(`[Unit]
Description=One shot service that appends static domains to etchosts
Before=network-online.target
Before=node-image-pull.service
...
```