### PR TITLE
fix: remove contradictory cycle

### DIFF
--- a/pkg/installer/etchost/etchosts.go
+++ b/pkg/installer/etchost/etchosts.go
@@ -80,7 +80,6 @@ cmp "${TEMP_FILE}" "${HOSTS_FILE}" || cp -f "${TEMP_FILE}" "${HOSTS_FILE}"
 
 var aroUnitTemplate = template.Must(template.New("etchostservice").Parse(`[Unit]
 Description=One shot service that appends static domains to etchosts
-Before=network-online.target
 Before=node-image-pull.service
 
 [Service]

--- a/pkg/installer/storage_files_testdata.go
+++ b/pkg/installer/storage_files_testdata.go
@@ -240,7 +240,6 @@ spec:
       - contents: |
           [Unit]
           Description=One shot service that appends static domains to etchosts
-          Before=network-online.target
           Before=node-image-pull.service
 
           [Service]
@@ -362,7 +361,6 @@ spec:
       - contents: |
           [Unit]
           Description=One shot service that appends static domains to etchosts
-          Before=network-online.target
           Before=node-image-pull.service
 
           [Service]

--- a/pkg/installer/systemd_files_testdata.go
+++ b/pkg/installer/systemd_files_testdata.go
@@ -6,7 +6,6 @@ package installer
 var expectedIgnitionServiceContents = map[string]string{
 	"aro-etchosts-resolver.service": `[Unit]
 Description=One shot service that appends static domains to etchosts
-Before=network-online.target
 Before=node-image-pull.service
 
 [Service]


### PR DESCRIPTION
ARO clusters with GatewayEnabled=true (UDR) were failing to install with OSProvisioningTimedOut on all three master nodes. 

Hypothesis: aro-etchosts-resolver.service had both Before=network-online.target and WantedBy=network-online.target with Type=oneshot, which creates a systemd ordering cycle.

```
(DeploymentFailed) Deployment failed due to OSProvisioningTimedOut. The cluster's virtual machines failed to start up in time. Please check your network configuration.
Code: DeploymentFailed
Message: Deployment failed due to OSProvisioningTimedOut. The cluster's virtual machines failed to start up in time. Please check your network configuration.
Exception Details:      (Conflict) {
          "status": "Failed",
          "error": {
            "code": "ResourceDeploymentFailure",
            "message": "The resource write operation failed to complete successfully, because it reached terminal provisioning state 'Failed'.",
            "details": [
              {
                "code": "OSProvisioningTimedOut",
                "message": "OS Provisioning for VM 'edison-udr-421-2-k68px-master-0' did not finish in the allotted time. The VM may still finish provisioning successfully. Please check provisioning state later. For details on how to check current provisioning state of Windows VMs, refer to https://aka.ms/WindowsVMLifecycle and Linux VMs, refer to https://aka.ms/LinuxVMLifecycle."
              }
            ]
          }
        }
    ...
```

The cycle:

- WantedBy=network-online.target -> network-online.target activates aro-etchosts-resolver
- Before=network-online.target + Type=oneshot -> network-online.target must wait for aro-etchosts-resolver to exit before it can proceed
- These two constraints together mean network-online.target both triggers and blocks on aro-etchosts-resolver — a deadlock

Systemd broke the cycle by skipping dnsmasq.

In service logs:
`[ SKIP ] Ordering cycle found, skipping DNS caching server.`


Assisted by: Copilot