### PR TITLE
ARO-28189: infer installer publish mode from ingress IP

### DIFF
--- a/pkg/installer/custominstallconfig.go
+++ b/pkg/installer/custominstallconfig.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openshift/installer/pkg/asset/installconfig"
 	"github.com/openshift/installer/pkg/asset/releaseimage"
 	targetassets "github.com/openshift/installer/pkg/asset/targets"
+	"github.com/openshift/installer/pkg/types"
 
 	"github.com/openshift/installer-aro-wrapper/pkg/cluster/graph"
 	bootstrapfiles "github.com/openshift/installer-aro-wrapper/pkg/data/bootstrap"
@@ -91,6 +92,11 @@ func (m *manager) applyInstallConfigCustomisations(ctx context.Context, installC
 		APIIntIP:  m.oc.Properties.APIServerProfile.IntIP,
 		IngressIP: m.oc.Properties.IngressProfiles[0].IP,
 	}
+
+	// Re-sync the caller-provided InstallConfig before graph resolution. This
+	// stage consumes the passed-in object directly, so we do not want stale
+	// Publish state to diverge from the current ingress profile.
+	installConfig.Config.Publish = ingressPublishStrategy(m.oc.Properties.IngressProfiles[0])
 
 	if m.oc.Properties.FeatureProfile.GatewayEnabled && m.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP != "" {
 		localdnsConfig.GatewayPrivateEndpointIP = m.oc.Properties.NetworkProfile.GatewayPrivateEndpointIP
@@ -156,7 +162,7 @@ func (m *manager) applyInstallConfigCustomisations(ctx context.Context, installC
 		AccountName:         imageRegistryConfig.AccountName,
 		ContainerName:       imageRegistryConfig.ContainerName,
 		CloudName:           installConfig.Config.Azure.CloudName.Name(),
-		AROIngressInternal:  installConfig.Config.Publish == "Internal",
+		AROIngressInternal:  installConfig.Config.Publish == types.InternalPublishingStrategy,
 		AROIngressIP:        localdnsConfig.IngressIP,
 	}
 	err = manifests.AppendManifestsFilesToBootstrap(bootstrapAsset, config)

--- a/pkg/installer/custominstallconfig_test.go
+++ b/pkg/installer/custominstallconfig_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 
 	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/installer/pkg/asset/ignition/bootstrap"
 	"github.com/openshift/installer/pkg/asset/ignition/machine"
 	"github.com/openshift/installer/pkg/asset/installconfig"
@@ -359,6 +360,35 @@ func TestApplyInstallConfigCustomisationsGatewayDisabled(t *testing.T) {
 	}
 }
 
+func TestApplyInstallConfigCustomisationsFallsBackToInternalWhenIngressIPIsPrivate(t *testing.T) {
+	ctx := context.Background()
+	m := fakeManager()
+	m.oc.Properties.IngressProfiles[0].IP = "10.0.0.10"
+	inInstallConfig := makeInstallConfig()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockClient := mock.NewMockAPI(mockCtrl)
+	inInstallConfig.Azure.UseMockClient(mockClient)
+	mockClientCalls(mockClient)
+
+	graph, err := m.applyInstallConfigCustomisations(ctx, inInstallConfig, makeImage())
+	require.NoError(t, err)
+
+	bootstrapAsset := graph.Get(&bootstrap.Bootstrap{}).(*bootstrap.Bootstrap)
+	routerServiceData := bootstrapFileContents(t, bootstrapAsset, "/opt/openshift/manifests/aro-ingress-service.yaml")
+	assert.Contains(t, string(routerServiceData), `service.beta.kubernetes.io/azure-load-balancer-internal: "true"`)
+	assert.Contains(t, string(routerServiceData), `service.beta.kubernetes.io/azure-load-balancer-ipv4: "10.0.0.10"`)
+
+	ingressControllerData := bootstrapFileContents(t, bootstrapAsset, "/opt/openshift/manifests/cluster-ingress-default-ingresscontroller.yaml")
+	ingressController := &operatorv1.IngressController{}
+	err = yaml.Unmarshal(ingressControllerData, ingressController)
+	require.NoError(t, err)
+	require.NotNil(t, ingressController.Spec.EndpointPublishingStrategy)
+	require.NotNil(t, ingressController.Spec.EndpointPublishingStrategy.LoadBalancer)
+	assert.Equal(t, operatorv1.InternalLoadBalancer, ingressController.Spec.EndpointPublishingStrategy.LoadBalancer.Scope)
+}
+
 func verifyIgnitionFiles(t *testing.T, temp map[string]any, storageFiles []string, systemdFiles []string, fileName string) {
 	files := (temp["storage"].(map[string]any))["files"].([]any)
 	systemd := (temp["systemd"].(map[string]any))["units"].([]any)
@@ -423,6 +453,36 @@ func verifyIgnitionFiles(t *testing.T, temp map[string]any, storageFiles []strin
 		t.Fatal(err)
 	}
 	assert.Equal(t, "ARO", config.Data["invoker"])
+}
+
+func bootstrapFileContents(t *testing.T, bootstrap *bootstrap.Bootstrap, path string) []byte {
+	t.Helper()
+
+	for _, file := range bootstrap.Config.Storage.Files {
+		if file.Path != path {
+			continue
+		}
+
+		switch {
+		case file.Contents.Source != nil:
+			parts := strings.SplitN(*file.Contents.Source, ",", 2)
+			require.Len(t, parts, 2, "expected data URL for %s", path)
+
+			decoded, err := base64.StdEncoding.DecodeString(parts[1])
+			require.NoError(t, err)
+			return decoded
+		case len(file.Append) > 0 && file.Append[0].Source != nil:
+			parts := strings.SplitN(*file.Append[0].Source, ",", 2)
+			require.Len(t, parts, 2, "expected appended data URL for %s", path)
+
+			decoded, err := base64.StdEncoding.DecodeString(parts[1])
+			require.NoError(t, err)
+			return decoded
+		}
+	}
+
+	t.Fatalf("file %s missing from bootstrap storage files", path)
+	return nil
 }
 
 func verifyMasterPointerIgnition(t *testing.T, ignData []byte) {

--- a/pkg/installer/generateconfig.go
+++ b/pkg/installer/generateconfig.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 
@@ -312,7 +313,7 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 						},
 					},
 				},
-				Publish: types.ExternalPublishingStrategy,
+				Publish: ingressPublishStrategy(m.oc.Properties.IngressProfiles[0]),
 				Capabilities: &types.Capabilities{
 					// don't include the baremetal capability (in the baseline default)
 					BaselineCapabilitySet: configv1.ClusterVersionCapabilitySetNone,
@@ -336,10 +337,6 @@ func (m *manager) generateInstallConfig(ctx context.Context) (*installconfig.Ins
 				},
 			},
 		},
-	}
-
-	if m.oc.Properties.IngressProfiles[0].Visibility == api.VisibilityPrivate {
-		installConfig.Config.Publish = types.InternalPublishingStrategy
 	}
 
 	var credentials *icazure.Credentials
@@ -417,6 +414,22 @@ func (m *manager) newInstallConfigClientCertificateCredential(tenantId, subscrip
 		ClientID:              m.env.FPClientID(),
 		ClientCertificatePath: clientCertificateFile.Name(),
 	}, nil
+}
+
+func ingressPublishStrategy(profile api.IngressProfile) types.PublishingStrategy {
+	switch profile.Visibility {
+	case api.VisibilityPrivate:
+		return types.InternalPublishingStrategy
+	case api.VisibilityPublic:
+		return types.ExternalPublishingStrategy
+	}
+
+	ip := net.ParseIP(profile.IP)
+	if ip != nil && ip.IsPrivate() {
+		return types.InternalPublishingStrategy
+	}
+
+	return types.ExternalPublishingStrategy
 }
 
 // determineSkuSupportsV2Only checks if the SKU ONLY supports HyperV Generation V2 (not V1).

--- a/pkg/installer/generateconfig_test.go
+++ b/pkg/installer/generateconfig_test.go
@@ -6,9 +6,11 @@ package installer
 import (
 	"testing"
 
+	"github.com/Azure/ARO-RP/pkg/api"
 	sdkcompute "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v7"
 	"github.com/Azure/go-autorest/autorest/to"
 
+	"github.com/openshift/installer/pkg/types"
 	"github.com/openshift/installer/pkg/types/azure"
 )
 
@@ -123,6 +125,60 @@ func TestDetermineSkuSupportsV2Only(t *testing.T) {
 
 			if result != tt.wantResult {
 				t.Errorf("expected %v, got %v", tt.wantResult, result)
+			}
+		})
+	}
+}
+
+func TestIngressPublishStrategy(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		profile api.IngressProfile
+		want    types.PublishingStrategy
+	}{
+		{
+			name: "explicit private visibility wins over IP",
+			profile: api.IngressProfile{
+				Visibility: api.VisibilityPrivate,
+				IP:         "203.0.113.10",
+			},
+			want: types.InternalPublishingStrategy,
+		},
+		{
+			name: "explicit public visibility wins over IP",
+			profile: api.IngressProfile{
+				Visibility: api.VisibilityPublic,
+				IP:         "10.0.0.10",
+			},
+			want: types.ExternalPublishingStrategy,
+		},
+		{
+			name: "missing visibility falls back to private IP",
+			profile: api.IngressProfile{
+				IP: "10.0.0.10",
+			},
+			want: types.InternalPublishingStrategy,
+		},
+		{
+			name: "missing visibility with public IP stays external",
+			profile: api.IngressProfile{
+				IP: "203.0.113.10",
+			},
+			want: types.ExternalPublishingStrategy,
+		},
+		{
+			name: "missing visibility with invalid IP stays external",
+			profile: api.IngressProfile{
+				IP: "not-an-ip",
+			},
+			want: types.ExternalPublishingStrategy,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ingressPublishStrategy(tt.profile)
+
+			if result != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, result)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- infer installer publish mode from the ingress profile using a shared helper instead of defaulting to external when visibility is missing
- keep `generateInstallConfig()` and `applyInstallConfigCustomisations()` converged on the same computed publish state before bootstrap rendering
- add regression tests proving that a private ingress IP yields both the internal `router-default` service annotation and the default private `IngressController` manifest

## Validation
- `go test -tags aro ./...`

## Alternatives discarded
- We did not make operator-populated ingress fields a runtime dependency of the installer path, because bootstrap rendering happens before operator reconciliation.
- We did not make bootstrap filename or apply-order changes the primary fix, because the stronger evidence pointed first to the missing-visibility plus private-IP publish mismatch.
- We did not mix the ARO-RP live-enrichment cleanup into this PR, because that is a separate concern and keeping this branch single-purpose keeps the review small.

## Notes
- This PR addresses the installer/bootstrap side of `ARO-28189`.
- The ARO-RP cleanup lives in a separate draft PR.
- The live repro-cluster mitigation validation was tracked separately for Jira/support and is not part of this code diff.
