### PR TITLE
DNS Ordering cycle fix

### DIFF
--- a/pkg/installer/dnsmasq/scripts/dnsmasq.service.gotmpl
+++ b/pkg/installer/dnsmasq/scripts/dnsmasq.service.gotmpl
@@ -1,8 +1,7 @@
 {{ define "dnsmasq.service" }}
 [Unit]
 Description=DNS caching server.
-After=network-online.target
-Wants=network-online.target
+After=network.target
 Before=bootkube.service
 Before=node-image-pull.service
 

--- a/pkg/installer/etchost/etchosts.go
+++ b/pkg/installer/etchost/etchosts.go
@@ -80,6 +80,7 @@ cmp "${TEMP_FILE}" "${HOSTS_FILE}" || cp -f "${TEMP_FILE}" "${HOSTS_FILE}"
 
 var aroUnitTemplate = template.Must(template.New("etchostservice").Parse(`[Unit]
 Description=One shot service that appends static domains to etchosts
+After=network-online.target
 Before=node-image-pull.service
 
 [Service]
@@ -89,7 +90,7 @@ RemainAfterExit=yes
 ExecStart=/bin/bash /usr/local/bin/{{ .ScriptFileName }}
 
 [Install]
-WantedBy=network-online.target
+WantedBy=multi-user.target
 `))
 
 func GenerateEtcHostsAROConf(clusterDomain string, apiIntIP string, gatewayDomains []string, gatewayPrivateEndpointIP string) ([]byte, error) {

--- a/pkg/installer/etchost/etchosts.go
+++ b/pkg/installer/etchost/etchosts.go
@@ -88,6 +88,8 @@ Type=oneshot
 RemainAfterExit=yes
 # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts
 ExecStart=/bin/bash /usr/local/bin/{{ .ScriptFileName }}
+StandardOutput=journal+console
+StandardError=journal+console
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/installer/etchost/etchosts.go
+++ b/pkg/installer/etchost/etchosts.go
@@ -84,6 +84,7 @@ Before=node-image-pull.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts
 ExecStart=/bin/bash /usr/local/bin/{{ .ScriptFileName }}
 

--- a/pkg/installer/etchost/etchosts_test.go
+++ b/pkg/installer/etchost/etchosts_test.go
@@ -63,6 +63,20 @@ func TestGenerateEtcHostsAROUnit_OrderingCycle(t *testing.T) {
 				"generated unit:\n%s", unit)
 	}
 
+	if !strings.Contains(unit, "StandardOutput=journal+console") {
+		t.Errorf(
+			"unit MUST contain 'StandardOutput=journal+console': "+
+				"ordering to node-image-pull is preserved after removing Before=network-online.target\n\n"+
+				"generated unit:\n%s", unit)
+	}
+
+	if !strings.Contains(unit, "StandardError=journal+console") {
+		t.Errorf(
+			"unit MUST contain 'StandardError=journal+console': "+
+				"ordering to node-image-pull is preserved after removing Before=network-online.target\n\n"+
+				"generated unit:\n%s", unit)
+	}
+
 	if !strings.Contains(unit, "WantedBy=multi-user.target") {
 		t.Errorf(
 			"unit MUST contain 'WantedBy=multi-user.target' in [Install]\n\n"+

--- a/pkg/installer/etchost/etchosts_test.go
+++ b/pkg/installer/etchost/etchosts_test.go
@@ -30,7 +30,8 @@ import (
 //
 // Fix: remove Before=network-online.target.  The ordering is preserved
 // transitively:  aro-etchosts-resolver → Before → node-image-pull
-//                node-image-pull        → After  → network-online.target
+//
+//	node-image-pull        → After  → network-online.target
 func TestGenerateEtcHostsAROUnit_OrderingCycle(t *testing.T) {
 	unit, err := GenerateEtcHostsAROUnit()
 	if err != nil {
@@ -59,8 +60,8 @@ func TestGenerateEtcHostsAROUnit_OrderingCycle(t *testing.T) {
 
 	if !strings.Contains(unit, "RemainAfterExit=yes") {
 		t.Errorf(
-			"unit MUST contain 'RemainAfterExit=yes': keeps service active after " +
-				"execution so 'systemctl status' shows it ran successfully\n\n" +
+			"unit MUST contain 'RemainAfterExit=yes': keeps service active after "+
+				"execution so 'systemctl status' shows it ran successfully\n\n"+
 				"generated unit:\n%s", unit)
 	}
 
@@ -71,9 +72,9 @@ func TestGenerateEtcHostsAROUnit_OrderingCycle(t *testing.T) {
 				"generated unit:\n%s", unit)
 	}
 
-	if !strings.Contains(unit, "WantedBy=network-online.target") {
+	if !strings.Contains(unit, "WantedBy=multi-user.target") {
 		t.Errorf(
-			"unit MUST contain 'WantedBy=network-online.target' in [Install]\n\n"+
+			"unit MUST contain 'WantedBy=multi-user.target' in [Install]\n\n"+
 				"generated unit:\n%s", unit)
 	}
 }

--- a/pkg/installer/etchost/etchosts_test.go
+++ b/pkg/installer/etchost/etchosts_test.go
@@ -16,17 +16,8 @@ import (
 //	Before=network-online.target   (in [Unit])
 //	WantedBy=network-online.target (in [Install])
 //
-// On RHCOS (systemd 252) this creates a dependency cycle:
-//
 //	network-online.target wants  aro-etchosts-resolver  → activates it
 //	network-online.target waits  aro-etchosts-resolver  → must finish first (Before=)
-//
-// systemd 252 breaks the cycle by skipping dnsmasq.service entirely, which
-// logs "[ SKIP ] Ordering cycle found, skipping DNS caching server."  Without
-// dnsmasq, /etc/resolv.conf keeps the raw DHCP nameserver (172.16.0.0), so
-// arostgsvc.azurecr.io resolves to the public IP (40.64.135.171) which a UDR
-// blackholes → node-image-pull loops → bootstrap never becomes healthy →
-// all masters: OSProvisioningTimedOut.
 //
 // Fix: remove Before=network-online.target.  The ordering is preserved
 // transitively:  aro-etchosts-resolver → Before → node-image-pull

--- a/pkg/installer/etchost/etchosts_test.go
+++ b/pkg/installer/etchost/etchosts_test.go
@@ -1,0 +1,79 @@
+package etchost
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGenerateEtcHostsAROUnit_OrderingCycle is the regression test for the
+// ordering-cycle bug that caused OSProvisioningTimedOut on UDR clusters.
+//
+// Root cause: aro-etchosts-resolver.service had BOTH
+//
+//	Before=network-online.target   (in [Unit])
+//	WantedBy=network-online.target (in [Install])
+//
+// On RHCOS (systemd 252) this creates a dependency cycle:
+//
+//	network-online.target wants  aro-etchosts-resolver  → activates it
+//	network-online.target waits  aro-etchosts-resolver  → must finish first (Before=)
+//
+// systemd 252 breaks the cycle by skipping dnsmasq.service entirely, which
+// logs "[ SKIP ] Ordering cycle found, skipping DNS caching server."  Without
+// dnsmasq, /etc/resolv.conf keeps the raw DHCP nameserver (172.16.0.0), so
+// arostgsvc.azurecr.io resolves to the public IP (40.64.135.171) which a UDR
+// blackholes → node-image-pull loops → bootstrap never becomes healthy →
+// all masters: OSProvisioningTimedOut.
+//
+// Fix: remove Before=network-online.target.  The ordering is preserved
+// transitively:  aro-etchosts-resolver → Before → node-image-pull
+//                node-image-pull        → After  → network-online.target
+func TestGenerateEtcHostsAROUnit_OrderingCycle(t *testing.T) {
+	unit, err := GenerateEtcHostsAROUnit()
+	if err != nil {
+		t.Fatalf("GenerateEtcHostsAROUnit() error: %v", err)
+	}
+
+	// ── must NOT be present ──────────────────────────────────────────────────
+	//
+	// Before=network-online.target + WantedBy=network-online.target is the
+	// cycle.  If this line appears, dnsmasq will be skipped on RHCOS 252.
+	if strings.Contains(unit, "Before=network-online.target") {
+		t.Errorf(
+			"unit MUST NOT contain 'Before=network-online.target': "+
+				"combined with WantedBy=network-online.target this creates an "+
+				"ordering cycle that causes systemd 252 to skip dnsmasq.service\n\n"+
+				"generated unit:\n%s", unit)
+	}
+
+	// ── must be present ──────────────────────────────────────────────────────
+
+	if !strings.Contains(unit, "Type=oneshot") {
+		t.Errorf(
+			"unit MUST contain 'Type=oneshot': the service runs a script and exits\n\n"+
+				"generated unit:\n%s", unit)
+	}
+
+	if !strings.Contains(unit, "RemainAfterExit=yes") {
+		t.Errorf(
+			"unit MUST contain 'RemainAfterExit=yes': keeps service active after " +
+				"execution so 'systemctl status' shows it ran successfully\n\n" +
+				"generated unit:\n%s", unit)
+	}
+
+	if !strings.Contains(unit, "Before=node-image-pull.service") {
+		t.Errorf(
+			"unit MUST contain 'Before=node-image-pull.service': "+
+				"ordering to node-image-pull is preserved after removing Before=network-online.target\n\n"+
+				"generated unit:\n%s", unit)
+	}
+
+	if !strings.Contains(unit, "WantedBy=network-online.target") {
+		t.Errorf(
+			"unit MUST contain 'WantedBy=network-online.target' in [Install]\n\n"+
+				"generated unit:\n%s", unit)
+	}
+}

--- a/pkg/installer/storage_files_testdata.go
+++ b/pkg/installer/storage_files_testdata.go
@@ -243,10 +243,12 @@ spec:
           Before=node-image-pull.service
 
           [Service]
-          Type=oneshot          
-          RemainAfterExit=yes          
+          Type=oneshot
+          RemainAfterExit=yes
           # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts
           ExecStart=/bin/bash /usr/local/bin/aro-etchosts-resolver.sh
+          StandardOutput=journal+console
+          StandardError=journal+console
 
           [Install]
           WantedBy=multi-user.target
@@ -365,8 +367,12 @@ spec:
           Before=node-image-pull.service
 
           [Service]
-          Type=oneshot          RemainAfterExit=yes          # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts
+          Type=oneshot
+          RemainAfterExit=yes
+          # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts
           ExecStart=/bin/bash /usr/local/bin/aro-etchosts-resolver.sh
+          StandardOutput=journal+console
+          StandardError=journal+console
 
           [Install]
           WantedBy=multi-user.target

--- a/pkg/installer/storage_files_testdata.go
+++ b/pkg/installer/storage_files_testdata.go
@@ -243,7 +243,8 @@ spec:
           Before=node-image-pull.service
 
           [Service]
-          Type=oneshot
+          Type=oneshot          
+          RemainAfterExit=yes          
           # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts
           ExecStart=/bin/bash /usr/local/bin/aro-etchosts-resolver.sh
 
@@ -364,8 +365,7 @@ spec:
           Before=node-image-pull.service
 
           [Service]
-          Type=oneshot
-          # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts
+          Type=oneshot          RemainAfterExit=yes          # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts
           ExecStart=/bin/bash /usr/local/bin/aro-etchosts-resolver.sh
 
           [Install]

--- a/pkg/installer/storage_files_testdata.go
+++ b/pkg/installer/storage_files_testdata.go
@@ -158,8 +158,7 @@ spec:
 
           [Unit]
           Description=DNS caching server.
-          After=network-online.target
-          Wants=network-online.target
+          After=network.target
           Before=bootkube.service
           Before=node-image-pull.service
 
@@ -240,6 +239,7 @@ spec:
       - contents: |
           [Unit]
           Description=One shot service that appends static domains to etchosts
+          After=network-online.target
           Before=node-image-pull.service
 
           [Service]
@@ -249,7 +249,7 @@ spec:
           ExecStart=/bin/bash /usr/local/bin/aro-etchosts-resolver.sh
 
           [Install]
-          WantedBy=network-online.target
+          WantedBy=multi-user.target
         enabled: true
         name: aro-etchosts-resolver.service
   extensions: null
@@ -303,8 +303,7 @@ spec:
 
           [Unit]
           Description=DNS caching server.
-          After=network-online.target
-          Wants=network-online.target
+          After=network.target
           Before=bootkube.service
           Before=node-image-pull.service
 
@@ -362,6 +361,7 @@ spec:
       - contents: |
           [Unit]
           Description=One shot service that appends static domains to etchosts
+          After=network-online.target
           Before=node-image-pull.service
 
           [Service]
@@ -369,7 +369,7 @@ spec:
           ExecStart=/bin/bash /usr/local/bin/aro-etchosts-resolver.sh
 
           [Install]
-          WantedBy=network-online.target
+          WantedBy=multi-user.target
         enabled: true
         name: aro-etchosts-resolver.service
   extensions: null

--- a/pkg/installer/systemd_files_testdata.go
+++ b/pkg/installer/systemd_files_testdata.go
@@ -10,6 +10,7 @@ Before=node-image-pull.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts
 ExecStart=/bin/bash /usr/local/bin/aro-etchosts-resolver.sh
 

--- a/pkg/installer/systemd_files_testdata.go
+++ b/pkg/installer/systemd_files_testdata.go
@@ -14,6 +14,8 @@ Type=oneshot
 RemainAfterExit=yes
 # ExecStart will copy the hosts defined in /etc/hosts.d/aro.conf to /etc/hosts
 ExecStart=/bin/bash /usr/local/bin/aro-etchosts-resolver.sh
+StandardOutput=journal+console
+StandardError=journal+console
 
 [Install]
 WantedBy=multi-user.target
@@ -22,6 +24,9 @@ WantedBy=multi-user.target
 [Unit]
 Description=DNS caching server.
 After=network.target
+Before=bootkube.service
+Before=node-image-pull.service
+
 [Service]
 # ExecStartPre will create a copy of the customer current resolv.conf file and make it upstream DNS.
 # This file is a product of user DNS settings on the VNET. We will replace this file to point to

--- a/pkg/installer/systemd_files_testdata.go
+++ b/pkg/installer/systemd_files_testdata.go
@@ -6,6 +6,7 @@ package installer
 var expectedIgnitionServiceContents = map[string]string{
 	"aro-etchosts-resolver.service": `[Unit]
 Description=One shot service that appends static domains to etchosts
+After=network-online.target
 Before=node-image-pull.service
 
 [Service]
@@ -15,16 +16,12 @@ RemainAfterExit=yes
 ExecStart=/bin/bash /usr/local/bin/aro-etchosts-resolver.sh
 
 [Install]
-WantedBy=network-online.target
+WantedBy=multi-user.target
 `,
 	"dnsmasq.service": `
 [Unit]
 Description=DNS caching server.
-After=network-online.target
-Wants=network-online.target
-Before=bootkube.service
-Before=node-image-pull.service
-
+After=network.target
 [Service]
 # ExecStartPre will create a copy of the customer current resolv.conf file and make it upstream DNS.
 # This file is a product of user DNS settings on the VNET. We will replace this file to point to


### PR DESCRIPTION
Fixes
`[ SKIP ] Ordering cycle found, skipping DNS caching server.
`

Fix ecardena-udr-421-6-2h5dq-bootstrap
```
[  OK  ] Started DNS caching server..
         Starting Node Image Pull...
...
Red Hat Enterprise Linux CoreOS 9.6.20251023-0 (Plow)
Kernel 5.14.0-570.58.1.el9_6.x86_64 on an x86_64
```

DNS now starts healthy now  in bootstrap. This fix should now unblock the entire UDR install.

Fixes: https://redhat.atlassian.net/browse/ARO-27141, https://redhat.atlassian.net/browse/ARO-27270 and https://redhat.atlassian.net/browse/ARO-26052.

Assisted by Copilot.