### PR TITLE
OCPBUGS-99639: Iterate PEM blocks in pemToPrivateKey to handle EC PARAMETERS prefix

### DIFF
--- a/pkg/installer/aroboundsasigningkey.go
+++ b/pkg/installer/aroboundsasigningkey.go
@@ -4,6 +4,7 @@ package installer
 // Licensed under the Apache License 2.0.
 
 import (
+	"crypto"
 	"os"
 	"path/filepath"
 
@@ -43,12 +44,16 @@ func (sk *AROBoundSASigningKey) Load(f asset.FileFetcher) (bool, error) {
 		return false, err
 	}
 
-	rsaKey, err := tls.PemToPrivateKey(keyFile.Data)
+	privateKey, err := pemToPrivateKey(keyFile.Data)
 	if err != nil {
-		logrus.Debugf("Failed to load rsa.PrivateKey from file: %s", err)
-		return false, errors.Wrap(err, "failed to load rsa.PrivateKey from the file")
+		logrus.Debugf("Failed to load private key from file: %s", err)
+		return false, errors.Wrap(err, "failed to load private key from the file")
 	}
-	pubData, err := tls.PublicKeyToPem(&rsaKey.PublicKey)
+	signer, ok := privateKey.(crypto.Signer)
+	if !ok {
+		return false, errors.New("private key does not implement crypto.Signer")
+	}
+	pubData, err := publicKeyToPem(signer.Public())
 	if err != nil {
 		return false, errors.Wrap(err, "failed to extract public key from the key")
 	}

--- a/pkg/installer/custominstallconfig_test.go
+++ b/pkg/installer/custominstallconfig_test.go
@@ -34,7 +34,6 @@ import (
 	icazure "github.com/openshift/installer/pkg/asset/installconfig/azure"
 	"github.com/openshift/installer/pkg/asset/installconfig/azure/mock"
 	"github.com/openshift/installer/pkg/asset/releaseimage"
-	"github.com/openshift/installer/pkg/asset/tls"
 	"github.com/openshift/installer/pkg/ipnet"
 	"github.com/openshift/installer/pkg/types"
 	azuretypes "github.com/openshift/installer/pkg/types/azure"
@@ -506,7 +505,7 @@ func verifyUpdateMCSCertKey(t *testing.T, bootstrap *bootstrap.Bootstrap) {
 			}
 			rawCert = decodedCert
 			assert.NotNil(t, rawCert)
-			cert, err = tls.PemToCertificate(decodedCert)
+			cert, err = pemToCertificate(decodedCert)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/installer/pemutils.go
+++ b/pkg/installer/pemutils.go
@@ -1,0 +1,56 @@
+package installer
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+)
+
+func pemToPrivateKey(data []byte) (crypto.PrivateKey, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("could not find a PEM block in the private key")
+	}
+
+	switch block.Type {
+	case "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
+	case "EC PRIVATE KEY":
+		return x509.ParseECPrivateKey(block.Bytes)
+	case "PRIVATE KEY":
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		switch key.(type) {
+		case *rsa.PrivateKey, *ecdsa.PrivateKey:
+			return key, nil
+		default:
+			return nil, fmt.Errorf("unsupported PKCS#8 key type: %T", key)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported PEM block type: %s", block.Type)
+	}
+}
+
+func pemToCertificate(data []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("could not find a PEM block in the certificate")
+	}
+	return x509.ParseCertificate(block.Bytes)
+}
+
+func publicKeyToPem(pub crypto.PublicKey) ([]byte, error) {
+	keyBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal public key: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: keyBytes}), nil
+}

--- a/pkg/installer/pemutils.go
+++ b/pkg/installer/pemutils.go
@@ -13,38 +13,46 @@ import (
 )
 
 func pemToPrivateKey(data []byte) (crypto.PrivateKey, error) {
-	block, _ := pem.Decode(data)
-	if block == nil {
-		return nil, fmt.Errorf("could not find a PEM block in the private key")
-	}
+	for {
+		var block *pem.Block
+		block, data = pem.Decode(data)
+		if block == nil {
+			break
+		}
 
-	switch block.Type {
-	case "RSA PRIVATE KEY":
-		return x509.ParsePKCS1PrivateKey(block.Bytes)
-	case "EC PRIVATE KEY":
-		return x509.ParseECPrivateKey(block.Bytes)
-	case "PRIVATE KEY":
-		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
-		if err != nil {
-			return nil, err
+		switch block.Type {
+		case "RSA PRIVATE KEY":
+			if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+				return key, nil
+			}
+		case "EC PRIVATE KEY":
+			if key, err := x509.ParseECPrivateKey(block.Bytes); err == nil {
+				return key, nil
+			}
+		case "PRIVATE KEY":
+			if key, err := x509.ParsePKCS8PrivateKey(block.Bytes); err == nil {
+				switch key.(type) {
+				case *rsa.PrivateKey, *ecdsa.PrivateKey:
+					return key, nil
+				}
+			}
 		}
-		switch key.(type) {
-		case *rsa.PrivateKey, *ecdsa.PrivateKey:
-			return key, nil
-		default:
-			return nil, fmt.Errorf("unsupported PKCS#8 key type: %T", key)
-		}
-	default:
-		return nil, fmt.Errorf("unsupported PEM block type: %s", block.Type)
 	}
+	return nil, fmt.Errorf("data does not contain a valid RSA or ECDSA private key")
 }
 
 func pemToCertificate(data []byte) (*x509.Certificate, error) {
-	block, _ := pem.Decode(data)
-	if block == nil {
-		return nil, fmt.Errorf("could not find a PEM block in the certificate")
+	for {
+		var block *pem.Block
+		block, data = pem.Decode(data)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			return x509.ParseCertificate(block.Bytes)
+		}
 	}
-	return x509.ParseCertificate(block.Bytes)
+	return nil, fmt.Errorf("data does not contain a valid certificate")
 }
 
 func publicKeyToPem(pub crypto.PublicKey) ([]byte, error) {

--- a/pkg/installer/pemutils_test.go
+++ b/pkg/installer/pemutils_test.go
@@ -1,0 +1,203 @@
+package installer
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the Apache License 2.0.
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func TestPemToPrivateKey(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rsaPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(rsaKey),
+	})
+
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ecDER, err := x509.MarshalECPrivateKey(ecKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ecPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: ecDER,
+	})
+
+	ecParamsOID, err := asn1.Marshal(ecKey.Curve.Params().Name)
+	if err != nil {
+		ecParamsOID = []byte("bogus-params")
+	}
+	ecParamsBlock := pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PARAMETERS",
+		Bytes: ecParamsOID,
+	})
+
+	ecPKCS8DER, err := x509.MarshalPKCS8PrivateKey(ecKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ecPKCS8PEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: ecPKCS8DER,
+	})
+
+	testCases := []struct {
+		name    string
+		data    []byte
+		wantRSA bool
+		wantEC  bool
+		wantErr bool
+	}{
+		{
+			name:    "RSA PKCS1 key",
+			data:    rsaPEM,
+			wantRSA: true,
+		},
+		{
+			name:   "EC key",
+			data:   ecPEM,
+			wantEC: true,
+		},
+		{
+			name:   "EC key with EC PARAMETERS prefix",
+			data:   append(ecParamsBlock, ecPEM...),
+			wantEC: true,
+		},
+		{
+			name:   "EC PKCS8 key",
+			data:   ecPKCS8PEM,
+			wantEC: true,
+		},
+		{
+			name:   "EC PKCS8 key with EC PARAMETERS prefix",
+			data:   append(ecParamsBlock, ecPKCS8PEM...),
+			wantEC: true,
+		},
+		{
+			name:    "RSA key with EC PARAMETERS prefix",
+			data:    append(ecParamsBlock, rsaPEM...),
+			wantRSA: true,
+		},
+		{
+			name:    "empty data",
+			data:    []byte{},
+			wantErr: true,
+		},
+		{
+			name:    "no key blocks",
+			data:    ecParamsBlock,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			key, err := pemToPrivateKey(tc.data)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			switch {
+			case tc.wantRSA:
+				if _, ok := key.(*rsa.PrivateKey); !ok {
+					t.Fatalf("expected *rsa.PrivateKey, got %T", key)
+				}
+			case tc.wantEC:
+				if _, ok := key.(*ecdsa.PrivateKey); !ok {
+					t.Fatalf("expected *ecdsa.PrivateKey, got %T", key)
+				}
+			}
+		})
+	}
+}
+
+func TestPemToCertificate(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+
+	nonCertBlock := pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PARAMETERS",
+		Bytes: []byte("bogus"),
+	})
+
+	testCases := []struct {
+		name    string
+		data    []byte
+		wantErr bool
+	}{
+		{
+			name: "valid certificate",
+			data: certPEM,
+		},
+		{
+			name: "certificate preceded by non-cert block",
+			data: append(nonCertBlock, certPEM...),
+		},
+		{
+			name:    "empty data",
+			data:    []byte{},
+			wantErr: true,
+		},
+		{
+			name:    "no certificate blocks",
+			data:    nonCertBlock,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cert, err := pemToCertificate(tc.data)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cert.Subject.CommonName != "test" {
+				t.Fatalf("expected CN 'test', got %q", cert.Subject.CommonName)
+			}
+		})
+	}
+}

--- a/pkg/installer/regenerate_mcs_certs.go
+++ b/pkg/installer/regenerate_mcs_certs.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"net"
 	"strings"
@@ -39,40 +40,42 @@ const (
 	header = "data:text/plain;charset=utf-8;base64,"
 )
 
-// RegenerateSignedCertKey regenerates a cert/key pair signed by the specified parent CA.
+// regenerateSignedCertKey regenerates a cert/key pair signed by the specified parent CA.
 // It does not write the cert/key pair to an asset file.
 func regenerateSignedCertKey(
 	cfg *tls.CertCfg,
 	parentCA tls.CertKeyInterface,
 	appendParent tls.AppendParentChoice,
 ) ([]byte, []byte, error) {
-	var key *rsa.PrivateKey
-	var crt *x509.Certificate
-	var err error
-
-	caKey, err := tls.PemToPrivateKey(parentCA.Key())
+	caKeyRaw, err := pemToPrivateKey(parentCA.Key())
 	if err != nil {
-		logrus.Debugf("Failed to parse RSA private key: %s", err)
-		return nil, nil, errors.Wrap(err, "failed to parse rsa private key")
+		logrus.Debugf("Failed to parse private key: %s", err)
+		return nil, nil, errors.Wrap(err, "failed to parse private key")
 	}
 
-	caCert, err := tls.PemToCertificate(parentCA.Cert())
+	caKey, ok := caKeyRaw.(*rsa.PrivateKey)
+	if !ok {
+		return nil, nil, fmt.Errorf("expected RSA private key, got %T", caKeyRaw)
+	}
+
+	caCert, err := pemToCertificate(parentCA.Cert())
 	if err != nil {
 		logrus.Debugf("Failed to parse x509 certificate: %s", err)
 		return nil, nil, errors.Wrap(err, "failed to parse x509 certificate")
 	}
 
-	key, crt, err = tls.GenerateSignedCertificate(caKey, caCert, cfg)
+	key, crt, err := tls.GenerateSignedCertificate(caKey, caCert, cfg)
 	if err != nil {
 		logrus.Debugf("Failed to generate signed cert/key pair: %s", err)
 		return nil, nil, errors.Wrap(err, "failed to generate signed cert/key pair")
 	}
 
-	keyRaw := tls.PrivateKeyToPem(key)
-	certRaw := tls.CertToPem(crt)
+	keyRaw := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	certRaw := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: crt.Raw})
 
 	if appendParent {
-		certRaw = bytes.Join([][]byte{certRaw, tls.CertToPem(caCert)}, []byte("\n"))
+		caCertRaw := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCert.Raw})
+		certRaw = bytes.Join([][]byte{certRaw, caCertRaw}, []byte("\n"))
 	}
 
 	return keyRaw, certRaw, nil


### PR DESCRIPTION
## Summary
- Replace single `pem.Decode` call with a loop in `pemToPrivateKey` and `pemToCertificate` to iterate through all PEM blocks
- OpenSSL-generated EC private key files can include an `EC PARAMETERS` block before the `EC PRIVATE KEY` block; the single-decode call read only the first block and returned an error instead of parsing the valid key
- Matches the iteration pattern used by `k8s.io/client-go/util/keyutil.ParsePrivateKeyPEM`, which explicitly tolerates non-key blocks like `EC PARAMETERS`

## Changes
1. **`pkg/installer/pemutils.go`**: Both `pemToPrivateKey` and `pemToCertificate` now loop through all PEM blocks, skipping unrecognized block types (e.g., `EC PARAMETERS`) until a valid key or certificate is found
2. **`pkg/installer/pemutils_test.go`**: New test coverage for RSA, EC, PKCS8 keys, and multi-block PEM input with EC PARAMETERS prefix

## Related Issues
- [OCPBUGS-99637](https://redhat.atlassian.net/browse/OCPBUGS-99637) - same fix in openshift/installer ([installer#10720](https://github.com/openshift/installer/pull/10720))
- [OCPBUGS-99638](https://redhat.atlassian.net/browse/OCPBUGS-99638) - same issue in hypershift

## Test plan
- [x] Unit tests pass for `pemToPrivateKey` with RSA, EC, and PKCS8 keys
- [x] Unit tests pass for `pemToPrivateKey` with EC PARAMETERS prefix block (the bug scenario)
- [x] Unit tests pass for `pemToCertificate` with non-cert prefix blocks
- [x] Full `go test ./pkg/installer/` passes on release-4.21