### PR TITLE
[ARO-22145] Bump FluentBit to 5.0.0 and Azure Linux 3

### DIFF
--- a/pkg/util/version/const.go
+++ b/pkg/util/version/const.go
@@ -19,7 +19,7 @@ const (
 
 // FluentbitImage contains the location of the Fluentbit container image
 func FluentbitImage(acrDomain string) string {
-	return acrDomain + "/fluentbit:4.2.2-cm20260102@sha256:1fff6f37417000c443cfd0812b5a5ac27af2480215b848335dfb48f68b8e1c7f"
+	return acrDomain + "/fluentbit:5.0.0-cm3.0.20260519@sha256:70f23886afaedfef5fd9b3488fd82ef43b6cb7534d19d544cb6f0eecfd25659a"
 }
 
 // MdsdImage contains the location of the MDSD container image


### PR DESCRIPTION
### Which issue this PR addresses:
Part of [ARO-22145](https://redhat.atlassian.net/browse/ARO-22145) — Migrate ARO RP/Gateway VMSS from Azure Linux 2.0 to Azure Linux 3.0.
### What this PR does / why we need it:
Updates the installer-aro-wrapper to align with the Azure Linux 3 migration in [ARO-RP#4766](https://github.com/Azure/ARO-RP/pull/4766):
- Bumps FluentBit from 4.2.2 (Azure Linux 2) to **5.0.0-cm3.0.20260519** (Azure Linux 3)
- Updates the base image version to **Microsoft Linux 3.0.20260519**
### Test plan:
- Validated on Stage and Canary environments (see [ARO-22197](https://redhat.atlassian.net/browse/ARO-22197))
- FluentBit 5.0.0 container starts and ships logs successfully on AL3 FIPS nodes
### Is there any documentation that needs to be updated for this PR?
No.
### How do you know this will function as expected in production?
Tested end-to-end on Stage and Canary with Azure Linux 3.0.20260519 FIPS images. Log collection via FluentBit 5.0.0 confirmed working.