### PR TITLE
[ARO-29244] [release-4.19] Update the ARO-RP api version in 4.19

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.5
 
 require (
-	github.com/Azure/ARO-RP/pkg/api v0.0.0-20260501080605-2acf55f49287
+	github.com/Azure/ARO-RP/pkg/api v0.0.0-20260625191944-7d3e42bd8ad5 // v20260625.03
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/Antonboom/nilnil v1.0.1 h1:C3Tkm0KUxgfO4Duk3PM+ztPncTFlOf0b2qadmS0s4x
 github.com/Antonboom/nilnil v1.0.1/go.mod h1:CH7pW2JsRNFgEh8B2UaPZTEPhCMuFowP/e8Udp9Nnb0=
 github.com/Antonboom/testifylint v1.5.2 h1:4s3Xhuv5AvdIgbd8wOOEeo0uZG7PbDKQyKY5lGoQazk=
 github.com/Antonboom/testifylint v1.5.2/go.mod h1:vxy8VJ0bc6NavlYqjZfmp6EfqXMtBgQ4+mhCojwC1P8=
-github.com/Azure/ARO-RP/pkg/api v0.0.0-20260501080605-2acf55f49287 h1:EtxovoCMr+9VkbdgTmj29bYmkH8YwSHnUrGSjJsbhas=
-github.com/Azure/ARO-RP/pkg/api v0.0.0-20260501080605-2acf55f49287/go.mod h1:BeVsNGii1id8YiLjA3HFObV+Kje3vdcmSvesf1NGeWs=
+github.com/Azure/ARO-RP/pkg/api v0.0.0-20260625191944-7d3e42bd8ad5 h1:Gfle1iCoNyaPm8/p1JLJAERnzDGspp40uNJYTn1wnVk=
+github.com/Azure/ARO-RP/pkg/api v0.0.0-20260625191944-7d3e42bd8ad5/go.mod h1:BeVsNGii1id8YiLjA3HFObV+Kje3vdcmSvesf1NGeWs=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
 github.com/Azure/azure-sdk-for-go v68.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0 h1:JXg2dwJUmPB9JmtVmdEB16APJ7jurfbY5jnfXpJoRMc=

--- a/vendor/github.com/Azure/ARO-RP/pkg/api/gatewaydocument.go
+++ b/vendor/github.com/Azure/ARO-RP/pkg/api/gatewaydocument.go
@@ -15,6 +15,20 @@ func (c *GatewayDocuments) String() string {
 	return encodeJSON(c)
 }
 
+func (c *GatewayDocuments) GetCount() int {
+	if c == nil {
+		return 0
+	}
+	return c.Count
+}
+
+func (c *GatewayDocuments) Docs() []*GatewayDocument {
+	if c == nil {
+		return []*GatewayDocument{}
+	}
+	return c.GatewayDocuments
+}
+
 // GatewayDocument represents a gateway document.
 // pkg/database/cosmosdb requires its definition.
 type GatewayDocument struct {

--- a/vendor/github.com/Azure/ARO-RP/pkg/api/openshiftcluster.go
+++ b/vendor/github.com/Azure/ARO-RP/pkg/api/openshiftcluster.go
@@ -496,6 +496,7 @@ const (
 	VMSizeStandardD8dsV5  VMSize = "Standard_D8ds_v5"
 	VMSizeStandardD16dsV5 VMSize = "Standard_D16ds_v5"
 	VMSizeStandardD32dsV5 VMSize = "Standard_D32ds_v5"
+	VMSizeStandardD48dsV5 VMSize = "Standard_D48ds_v5"
 	VMSizeStandardD64dsV5 VMSize = "Standard_D64ds_v5"
 	VMSizeStandardD96dsV5 VMSize = "Standard_D96ds_v5"
 
@@ -669,6 +670,7 @@ var (
 	VMSizeStandardD8dsV5Struct  = VMSizeStruct{CoreCount: 8, Family: standardDDSv5}
 	VMSizeStandardD16dsV5Struct = VMSizeStruct{CoreCount: 16, Family: standardDDSv5}
 	VMSizeStandardD32dsV5Struct = VMSizeStruct{CoreCount: 32, Family: standardDDSv5}
+	VMSizeStandardD48dsV5Struct = VMSizeStruct{CoreCount: 48, Family: standardDDSv5}
 	VMSizeStandardD64dsV5Struct = VMSizeStruct{CoreCount: 64, Family: standardDDSv5}
 	VMSizeStandardD96dsV5Struct = VMSizeStruct{CoreCount: 96, Family: standardDDSv5}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ cloud.google.com/go/storage/internal/apiv2/storagepb
 github.com/AlecAivazis/survey/v2
 github.com/AlecAivazis/survey/v2/core
 github.com/AlecAivazis/survey/v2/terminal
-# github.com/Azure/ARO-RP/pkg/api v0.0.0-20260501080605-2acf55f49287
+# github.com/Azure/ARO-RP/pkg/api v0.0.0-20260625191944-7d3e42bd8ad5
 ## explicit; go 1.24.0
 github.com/Azure/ARO-RP/pkg/api
 github.com/Azure/ARO-RP/pkg/api/util/uuid


### PR DESCRIPTION
[redhat.atlassian.net/browse/ARO-29244](https://redhat.atlassian.net/browse/ARO-29244)

Moves to ARO-RP's pkg/api